### PR TITLE
Refactor table filter toolbar and navigation layout

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,0 +1,113 @@
+import { Link } from '@tanstack/react-router'
+import { ChevronRight } from 'lucide-react'
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+    Sidebar,
+    SidebarContent,
+    SidebarHeader,
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    SidebarMenuSub,
+    SidebarMenuSubButton,
+    SidebarMenuSubItem,
+    SidebarRail,
+} from '@/components/ui/sidebar'
+import { TABLES } from '@/services/db'
+import { TABLE_GROUPS, SUMMARY_GROUPS } from '@/config/navigation'
+
+export function AppSidebar() {
+    return (
+        <Sidebar>
+            <SidebarHeader>
+                <div className="flex items-center justify-between px-2 py-1.5">
+                    <span className="font-semibold">Canavalle</span>
+                </div>
+            </SidebarHeader>
+            <SidebarContent className="gap-0">
+                <SidebarMenu>
+                    <Collapsible defaultOpen className="group/collapsible">
+                        <SidebarMenuItem>
+                            <CollapsibleTrigger asChild>
+                                <SidebarMenuButton>
+                                    <span>Tablas</span>
+                                    <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                                </SidebarMenuButton>
+                            </CollapsibleTrigger>
+                            <CollapsibleContent>
+                                <SidebarMenuSub>
+                                    {TABLE_GROUPS.map((group) => (
+                                        <Collapsible key={group.label} defaultOpen className="group/collapsible">
+                                            <SidebarMenuSubItem>
+                                                <CollapsibleTrigger asChild>
+                                                    <SidebarMenuSubButton size="sm">
+                                                        <span>{group.label}</span>
+                                                        <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                                                    </SidebarMenuSubButton>
+                                                </CollapsibleTrigger>
+                                                <CollapsibleContent>
+                                                    <SidebarMenuSub className="ml-1">
+                                                        {group.items
+                                                            .map((id) => TABLES[id])
+                                                            .filter((t): t is NonNullable<typeof t> => Boolean(t))
+                                                            .map((t) => (
+                                                                <SidebarMenuSubItem key={t.id}>
+                                                                    <SidebarMenuSubButton asChild size="sm">
+                                                                        <Link
+                                                                            to="/db/$table"
+                                                                            params={{ table: t.id }}
+                                                                            activeProps={{ 'data-active': 'true' }}
+                                                                        >
+                                                                            <span>{t.title}</span>
+                                                                        </Link>
+                                                                    </SidebarMenuSubButton>
+                                                                </SidebarMenuSubItem>
+                                                            ))}
+                                                    </SidebarMenuSub>
+                                                </CollapsibleContent>
+                                            </SidebarMenuSubItem>
+                                        </Collapsible>
+                                    ))}
+                                </SidebarMenuSub>
+                            </CollapsibleContent>
+                        </SidebarMenuItem>
+                    </Collapsible>
+                    {SUMMARY_GROUPS.map((group) => (
+                        <Collapsible key={group.label} defaultOpen className="group/collapsible">
+                            <SidebarMenuItem>
+                                <CollapsibleTrigger asChild>
+                                    <SidebarMenuButton>
+                                        <span>{group.label}</span>
+                                        <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                                    </SidebarMenuButton>
+                                </CollapsibleTrigger>
+                                <CollapsibleContent>
+                                    <SidebarMenuSub>
+                                        {group.items.map((item) => (
+                                            <SidebarMenuSubItem key={item.to}>
+                                                <SidebarMenuSubButton asChild size="sm">
+                                                    <Link
+                                                        to={item.to}
+                                                        activeProps={{ 'data-active': 'true' }}
+                                                    >
+                                                        <span>{item.label}</span>
+                                                    </Link>
+                                                </SidebarMenuSubButton>
+                                            </SidebarMenuSubItem>
+                                        ))}
+                                    </SidebarMenuSub>
+                                </CollapsibleContent>
+                            </SidebarMenuItem>
+                        </Collapsible>
+                    ))}
+                </SidebarMenu>
+            </SidebarContent>
+            <SidebarRail />
+        </Sidebar>
+    )
+}
+

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,0 +1,36 @@
+export type TableNavigationGroup = { label: string; items: string[] }
+
+export const TABLE_GROUPS: ReadonlyArray<TableNavigationGroup> = [
+    { label: 'Estructura de Finca', items: ['finca', 'bloque', 'cama', 'grupo_cama', 'seccion'] },
+    { label: 'Variedades', items: ['variedad', 'breeder', 'patron'] },
+    { label: 'Fenología', items: ['estados_fenologicos', 'estado_fenologico_tipo'] },
+    { label: 'Observaciones', items: ['observacion'] },
+    { label: 'Catálogos', items: ['grupo_cama_estado', 'grupo_cama_tipo_planta'] },
+    { label: 'Sistema', items: ['usuario'] },
+] as const
+
+export type SummaryRoute =
+    | '/estimados/area'
+    | '/estimados/observaciones-area'
+    | '/estimados/observaciones-resumen'
+    | '/estimados/estimados'
+    | '/estimados/estimados-resumen'
+
+export type SummaryNavigationGroup = {
+    label: string
+    items: Array<{ to: SummaryRoute; label: string }>
+}
+
+export const SUMMARY_GROUPS: ReadonlyArray<SummaryNavigationGroup> = [
+    {
+        label: 'Resumenes',
+        items: [
+            { to: '/estimados/area', label: 'Área productiva por variedad' },
+            { to: '/estimados/observaciones-area', label: 'Observaciones + área productiva' },
+            { to: '/estimados/observaciones-resumen', label: 'Resumen observaciones por cama' },
+            { to: '/estimados/estimados', label: 'Estimados' },
+            { to: '/estimados/estimados-resumen', label: 'Resumen fenológico (b)' },
+        ],
+    },
+] as const
+

--- a/src/features/table-filter/filter-toolbar.tsx
+++ b/src/features/table-filter/filter-toolbar.tsx
@@ -1,0 +1,276 @@
+import * as React from 'react'
+import type { TableFilterState } from '@/hooks/use-table-filter'
+import { Input } from '@/components/ui/input'
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuLabel,
+} from '@/components/ui/dropdown-menu'
+import { ChevronRight as CaretDownIcon, Plus, X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { DatePicker, DateRangePicker, toISODate } from '@/components/date-picker'
+
+export type FilterToolbarProps = Pick<
+    TableFilterState,
+    'query' | 'setQuery' | 'column' | 'setColumn' | 'columns' | 'addFilter' | 'filters' | 'removeFilter' | 'clearFilters'
+>
+
+type OperatorDef = { value: string; label: string; types: Array<'string' | 'number' | 'date'> }
+
+const OPERATORS: OperatorDef[] = [
+    { value: 'contains', label: 'contiene', types: ['string'] },
+    { value: 'eq', label: '=', types: ['string', 'number', 'date'] },
+    { value: 'starts', label: 'empieza', types: ['string'] },
+    { value: 'ends', label: 'termina', types: ['string'] },
+    { value: 'gt', label: '>', types: ['number'] },
+    { value: 'lt', label: '<', types: ['number'] },
+    { value: 'gte', label: '≥', types: ['number'] },
+    { value: 'lte', label: '≤', types: ['number'] },
+    { value: 'between', label: 'entre', types: ['number', 'date'] },
+]
+
+export function FilterToolbar({
+    query,
+    setQuery,
+    column,
+    setColumn,
+    columns,
+    addFilter,
+    filters,
+    removeFilter,
+    clearFilters,
+}: FilterToolbarProps) {
+    const activeColumn = column === '*' ? null : columns.find((c) => c.key === column) || null
+    const activeLabel = activeColumn ? activeColumn.label : 'Todas las columnas'
+    const [op, setOp] = React.useState<string>('contains')
+    const [value2, setValue2] = React.useState('')
+    const [dateRange, setDateRange] = React.useState<{ from?: Date; to?: Date }>({})
+    const [singleDate, setSingleDate] = React.useState<Date | undefined>(undefined)
+
+    React.useEffect(() => {
+        if (!activeColumn) {
+            setOp('contains')
+            return
+        }
+        const t = activeColumn.type || 'string'
+        if (t === 'number' && !['gt', 'lt', 'gte', 'lte', 'eq', 'between'].includes(op)) setOp('eq')
+        if (t === 'date' && !['eq', 'between'].includes(op)) setOp('eq')
+        if (t === 'string' && !['contains', 'eq', 'starts', 'ends'].includes(op)) setOp('contains')
+    }, [activeColumn, op])
+
+    const availableOps = React.useMemo(() => {
+        const t = activeColumn?.type || 'string'
+        return OPERATORS.filter((o) => o.types.includes(t as OperatorDef['types'][number]))
+    }, [activeColumn])
+
+    const showSecond = op === 'between' && activeColumn && activeColumn.type === 'number'
+    const isDateMode = !!activeColumn && activeColumn.type === 'date'
+
+    const commitFilter = () => {
+        if (!activeColumn) return
+        if (isDateMode) {
+            if (op === 'between') {
+                if (!(dateRange.from && dateRange.to)) return
+                const a = toISODate(dateRange.from)
+                const b = toISODate(dateRange.to)
+                addFilter({ column: activeColumn.key, value: a, value2: b, op: 'between', type: 'date' })
+                setDateRange({})
+            } else {
+                if (!singleDate) return
+                const a = toISODate(singleDate)
+                addFilter({ column: activeColumn.key, value: a, op: 'eq', type: 'date' })
+                setSingleDate(undefined)
+            }
+            return
+        }
+        const base = query.trim()
+        if (!base) return
+        if (op === 'between' && showSecond) {
+            const b = value2.trim()
+            if (!b) return
+            addFilter({ column: activeColumn.key, value: base, value2: b, op, type: activeColumn.type || 'number' })
+            setQuery('')
+            setValue2('')
+            return
+        }
+        addFilter({ column: activeColumn.key, value: base, op, type: activeColumn.type || 'string' })
+        setQuery('')
+    }
+
+    return (
+        <div className="flex items-center gap-2 ml-auto min-w-0">
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <button className="inline-flex h-8 items-center gap-1 whitespace-nowrap rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground transition-colors">
+                        {activeLabel}
+                        <CaretDownIcon className="size-4 opacity-70" />
+                    </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-52">
+                    <DropdownMenuLabel className="text-xs uppercase tracking-wide">Columna</DropdownMenuLabel>
+                    <DropdownMenuRadioGroup value={column} onValueChange={(value) => setColumn(value)}>
+                        <DropdownMenuRadioItem value="*">Todas (búsqueda global)</DropdownMenuRadioItem>
+                        {columns.map((c) => (
+                            <DropdownMenuRadioItem key={c.key} value={c.key}>
+                                {c.label}
+                            </DropdownMenuRadioItem>
+                        ))}
+                    </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+            </DropdownMenu>
+            {activeColumn && (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <button className="inline-flex h-8 items-center gap-1 whitespace-nowrap rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground transition-colors">
+                            {availableOps.find((o) => o.value === op)?.label || op}
+                            <CaretDownIcon className="size-4 opacity-70" />
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-40">
+                        <DropdownMenuLabel className="text-xs uppercase tracking-wide">Operador</DropdownMenuLabel>
+                        <DropdownMenuRadioGroup value={op} onValueChange={(value) => setOp(value)}>
+                            {availableOps.map((o) => (
+                                <DropdownMenuRadioItem key={o.value} value={o.value}>
+                                    {o.label}
+                                </DropdownMenuRadioItem>
+                            ))}
+                        </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            )}
+            {!isDateMode && (
+                <div className="relative">
+                    <Input
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                                commitFilter()
+                            }
+                        }}
+                        placeholder={column === '*' ? 'Buscar (global)' : `Valor (${activeColumn?.label})`}
+                        className="h-8 w-40 pr-6"
+                    />
+                    {query && (
+                        <button
+                            onClick={() => setQuery('')}
+                            className="absolute right-1 top-1 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
+                            aria-label="Clear"
+                            type="button"
+                        >
+                            <X className="size-4" />
+                        </button>
+                    )}
+                </div>
+            )}
+            {showSecond && !isDateMode && (
+                <Input
+                    value={value2}
+                    onChange={(e) => setValue2(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            commitFilter()
+                        }
+                    }}
+                    placeholder="y"
+                    className="h-8 w-28"
+                />
+            )}
+            {isDateMode && op !== 'between' && (
+                <DatePicker
+                    value={singleDate}
+                    onChange={(d) => setSingleDate(d || undefined)}
+                    autoCloseOnSelect={false}
+                    onCommit={commitFilter}
+                    className="h-8"
+                />
+            )}
+            {isDateMode && op === 'between' && (
+                <DateRangePicker
+                    value={dateRange}
+                    onChange={(r) => setDateRange(r)}
+                    autoCloseOnSelect={false}
+                    onCommit={commitFilter}
+                    className="h-8"
+                />
+            )}
+            {!isDateMode && (
+                <button
+                    type="button"
+                    onClick={commitFilter}
+                    className="inline-flex h-8 items-center gap-1 rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+                    disabled={
+                        !activeColumn ||
+                        (op === 'between' && showSecond ? !(query.trim() && value2.trim()) : !query.trim())
+                    }
+                >
+                    <Plus className="size-4" />
+                    Añadir
+                </button>
+            )}
+            {isDateMode && (
+                <button
+                    type="button"
+                    onClick={commitFilter}
+                    className="inline-flex h-8 items-center gap-1 rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+                    disabled={!activeColumn || (op === 'between' ? !(dateRange.from && dateRange.to) : !singleDate)}
+                >
+                    <Plus className="size-4" />
+                    Añadir
+                </button>
+            )}
+            {filters.length > 0 && (
+                <div className="flex items-center gap-1 flex-wrap max-w-[360px]">
+                    {filters.map((f) => {
+                        const colLabel = columns.find((c) => c.key === f.column)?.label || f.column
+                        const opDef = OPERATORS.find((o) => o.value === f.op)?.label || f.op
+                        const displayVal =
+                            f.type === 'date'
+                                ? f.op === 'between'
+                                    ? `${disp(f.value)}–${disp(f.value2)}`
+                                    : disp(f.value)
+                                : f.op === 'between'
+                                    ? `${f.value}–${f.value2}`
+                                    : f.value
+                        return (
+                            <Badge
+                                key={f.id}
+                                className="group cursor-pointer"
+                                onClick={() => removeFilter(f.id)}
+                                title={`${colLabel} ${opDef} ${displayVal}`}
+                            >
+                                <span className="max-w-[140px] truncate">{colLabel} {opDef} {displayVal}</span>
+                                <X className="size-3 opacity-60 group-hover:opacity-100" />
+                            </Badge>
+                        )
+                    })}
+                    <button
+                        type="button"
+                        onClick={clearFilters}
+                        className="text-xs text-muted-foreground hover:text-foreground underline"
+                    >
+                        limpiar
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function fmt(d: Date) {
+    const y = d.getUTCFullYear()
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+    const da = String(d.getUTCDate()).padStart(2, '0')
+    return `${da}/${m}/${y}`
+}
+
+function disp(iso?: string) {
+    if (!iso) return ''
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return iso
+    return fmt(d)
+}
+

--- a/src/hooks/use-table-filter.tsx
+++ b/src/hooks/use-table-filter.tsx
@@ -12,7 +12,7 @@ export type SavedFilter = {
     type: 'string' | 'number' | 'date'
 }
 
-type TableFilterState = {
+export type TableFilterState = {
     query: string
     setQuery: (v: string) => void
     column: string // '*' means all columns for live query typing

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,265 +1,19 @@
-import { createRootRoute, Link, Outlet, useRouterState } from '@tanstack/react-router'
-import * as React from 'react'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { ChevronRight } from 'lucide-react'
-import {
-    Sidebar,
-    SidebarContent,
-    SidebarHeader,
-    SidebarInset,
-    SidebarMenu,
-    SidebarMenuButton,
-    SidebarMenuItem,
-    SidebarMenuSub,
-    SidebarMenuSubItem,
-    SidebarMenuSubButton,
-    SidebarProvider,
-    SidebarRail,
-    SidebarTrigger,
-} from '@/components/ui/sidebar'
+import { createRootRoute, Outlet, useRouterState } from '@tanstack/react-router'
+import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { TABLES } from '@/services/db'
 import { TableFilterProvider, useTableFilter } from '@/hooks/use-table-filter'
-import { Input } from '@/components/ui/input'
-import {
-    DropdownMenu,
-    DropdownMenuTrigger,
-    DropdownMenuContent,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-    DropdownMenuLabel,
-} from '@/components/ui/dropdown-menu'
-import { ChevronRight as CaretDownIcon } from 'lucide-react'
-import { Badge } from '@/components/ui/badge'
-import { Plus, X } from 'lucide-react'
-import { DatePicker, DateRangePicker, toISODate } from '@/components/date-picker'
+import { FilterToolbar } from '@/features/table-filter/filter-toolbar'
+import { AppSidebar } from '@/components/app-sidebar'
 
-type OperatorDef = { value: string; label: string; types: Array<'string' | 'number' | 'date'> }
-const OPERATORS: OperatorDef[] = [
-    { value: 'contains', label: 'contiene', types: ['string'] },
-    { value: 'eq', label: '=', types: ['string', 'number', 'date'] },
-    { value: 'starts', label: 'empieza', types: ['string'] },
-    { value: 'ends', label: 'termina', types: ['string'] },
-    { value: 'gt', label: '>', types: ['number'] },
-    { value: 'lt', label: '<', types: ['number'] },
-    { value: 'gte', label: '≥', types: ['number'] },
-    { value: 'lte', label: '≤', types: ['number'] },
-    { value: 'between', label: 'entre', types: ['number', 'date'] },
-]
+const RootLayout = () => (
+    <TableFilterProvider>
+        <SidebarProvider>
+            <RootShell />
+        </SidebarProvider>
+    </TableFilterProvider>
+)
 
-function FilterToolbar() {
-    const { query, setQuery, column, setColumn, columns, addFilter, filters, removeFilter, clearFilters } = useTableFilter()
-    const activeColumn = column === '*' ? null : columns.find(c => c.key === column) || null
-    const activeLabel = activeColumn ? activeColumn.label : 'Todas las columnas'
-    const [op, setOp] = React.useState<string>('contains')
-    const [value2, setValue2] = React.useState('')
-    const [dateRange, setDateRange] = React.useState<{ from?: Date; to?: Date }>({})
-    const [singleDate, setSingleDate] = React.useState<Date | undefined>(undefined)
-    const inputRef = React.useRef<HTMLInputElement | null>(null)
-
-    // Adjust default operator when column or its type changes
-    React.useEffect(() => {
-        if (!activeColumn) { setOp('contains'); return }
-        const t = activeColumn.type || 'string'
-        if (t === 'number' && !['gt', 'lt', 'gte', 'lte', 'eq', 'between'].includes(op)) setOp('eq')
-        if (t === 'date' && !['eq', 'between'].includes(op)) setOp('eq')
-        if (t === 'string' && !['contains', 'eq', 'starts', 'ends'].includes(op)) setOp('contains')
-    }, [activeColumn, op])
-
-    const availableOps = React.useMemo(() => {
-        const t = activeColumn?.type || 'string'
-        return OPERATORS.filter(o => o.types.includes(t as any))
-    }, [activeColumn])
-
-    const showSecond = op === 'between' && activeColumn && (activeColumn.type === 'number')
-    const isDateMode = !!activeColumn && activeColumn.type === 'date'
-
-    const commitFilter = () => {
-        if (!activeColumn) return // require a specific column
-        if (isDateMode) {
-            if (op === 'between') {
-                if (!(dateRange.from && dateRange.to)) return
-                const a = toISODate(dateRange.from)
-                const b = toISODate(dateRange.to)
-                addFilter({ column: activeColumn.key, value: a, value2: b, op: 'between', type: 'date' })
-                setDateRange({})
-            } else { // treat anything else as eq for dates
-                if (!singleDate) return
-                const a = toISODate(singleDate)
-                addFilter({ column: activeColumn.key, value: a, op: 'eq', type: 'date' })
-                setSingleDate(undefined)
-            }
-            return
-        }
-        const base = query.trim()
-        if (!base) return
-        if (op === 'between' && showSecond) {
-            const b = value2.trim()
-            if (!b) return
-            addFilter({ column: activeColumn.key, value: base, value2: b, op, type: activeColumn.type || 'number' })
-            setQuery('')
-            setValue2('')
-            return
-        }
-        addFilter({ column: activeColumn.key, value: base, op, type: activeColumn.type || 'string' })
-        setQuery('')
-    }
-
-    return (
-        <div className="flex items-center gap-2 ml-auto min-w-0">
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <button className="inline-flex h-8 items-center gap-1 whitespace-nowrap rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground transition-colors">
-                        {activeLabel}
-                        <CaretDownIcon className="size-4 opacity-70" />
-                    </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-52">
-                    <DropdownMenuLabel className="text-xs uppercase tracking-wide">Columna</DropdownMenuLabel>
-                    <DropdownMenuRadioGroup value={column} onValueChange={setColumn as any}>
-                        <DropdownMenuRadioItem value="*">Todas (búsqueda global)</DropdownMenuRadioItem>
-                        {columns.map(c => (
-                            <DropdownMenuRadioItem key={c.key} value={c.key}>{c.label}</DropdownMenuRadioItem>
-                        ))}
-                    </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-            </DropdownMenu>
-            {activeColumn && (
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <button className="inline-flex h-8 items-center gap-1 whitespace-nowrap rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground transition-colors">
-                            {availableOps.find(o => o.value === op)?.label || op}
-                            <CaretDownIcon className="size-4 opacity-70" />
-                        </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-40">
-                        <DropdownMenuLabel className="text-xs uppercase tracking-wide">Operador</DropdownMenuLabel>
-                        <DropdownMenuRadioGroup value={op} onValueChange={setOp as any}>
-                            {availableOps.map(o => (
-                                <DropdownMenuRadioItem key={o.value} value={o.value}>{o.label}</DropdownMenuRadioItem>
-                            ))}
-                        </DropdownMenuRadioGroup>
-                    </DropdownMenuContent>
-                </DropdownMenu>
-            )}
-            {!isDateMode && (
-                <div className="relative">
-                    <Input
-                        ref={inputRef}
-                        value={query}
-                        onChange={(e) => setQuery(e.target.value)}
-                        onKeyDown={(e) => { if (e.key === 'Enter') { commitFilter() } }}
-                        placeholder={column === '*' ? 'Buscar (global)' : `Valor (${activeColumn?.label})`}
-                        className="h-8 w-40 pr-6"
-                    />
-                    {query && (
-                        <button
-                            onClick={() => setQuery('')}
-                            className="absolute right-1 top-1 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
-                            aria-label="Clear"
-                            type="button"
-                        >
-                            <X className="size-4" />
-                        </button>
-                    )}
-                </div>
-            )}
-            {showSecond && !isDateMode && (
-                <Input
-                    value={value2}
-                    onChange={(e) => setValue2(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === 'Enter') { commitFilter() } }}
-                    placeholder="y"
-                    className="h-8 w-28"
-                />
-            )}
-            {isDateMode && op !== 'between' && (
-                <DatePicker
-                    value={singleDate}
-                    onChange={(d) => setSingleDate(d || undefined)}
-                    autoCloseOnSelect={false}
-                    onCommit={commitFilter}
-                    className="h-8"
-                />
-            )}
-            {isDateMode && op === 'between' && (
-                <DateRangePicker
-                    value={dateRange}
-                    onChange={(r) => setDateRange(r)}
-                    autoCloseOnSelect={false}
-                    onCommit={commitFilter}
-                    className="h-8"
-                />
-            )}
-            {(!isDateMode) && (
-                <button
-                    type="button"
-                    onClick={commitFilter}
-                    className="inline-flex h-8 items-center gap-1 rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-                    disabled={!activeColumn || (op === 'between' && showSecond ? !(query.trim() && value2.trim()) : !query.trim())}
-                >
-                    <Plus className="size-4" />
-                    Añadir
-                </button>
-            )}
-            {isDateMode && (
-                <button
-                    type="button"
-                    onClick={commitFilter}
-                    className="inline-flex h-8 items-center gap-1 rounded-md border px-2 text-sm shadow-xs hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-                    disabled={!activeColumn || (op === 'between' ? !(dateRange.from && dateRange.to) : !singleDate)}
-                >
-                    <Plus className="size-4" />
-                    Añadir
-                </button>
-            )}
-            {filters.length > 0 && (
-                <div className="flex items-center gap-1 flex-wrap max-w-[360px]">
-                    {filters.map(f => {
-                        const colLabel = columns.find(c => c.key === f.column)?.label || f.column
-                        const opDef = OPERATORS.find(o => o.value === f.op)?.label || f.op
-                        const displayVal = f.type === 'date'
-                            ? (f.op === 'between' ? `${disp(f.value)}–${disp(f.value2)}` : disp(f.value))
-                            : (f.op === 'between' ? `${f.value}–${f.value2}` : f.value)
-                        return (
-                            <Badge key={f.id} className="group cursor-pointer" onClick={() => removeFilter(f.id)} title={`${colLabel} ${opDef} ${displayVal}`}>
-                                <span className="max-w-[140px] truncate">{colLabel} {opDef} {displayVal}</span>
-                                <X className="size-3 opacity-60 group-hover:opacity-100" />
-                            </Badge>
-                        )
-                    })}
-                    <button
-                        type="button"
-                        onClick={clearFilters}
-                        className="text-xs text-muted-foreground hover:text-foreground underline"
-                    >
-                        limpiar
-                    </button>
-                </div>
-            )}
-        </div>
-    )
-}
-
-function fmt(d: Date) {
-    const y = d.getUTCFullYear(); const m = String(d.getUTCMonth() + 1).padStart(2, '0'); const da = String(d.getUTCDate()).padStart(2, '0'); return `${da}/${m}/${y}`
-}
-function disp(iso?: string) {
-    if (!iso) return ''
-    const d = new Date(iso)
-    if (isNaN(d.getTime())) return iso
-    return fmt(d)
-}
-
-const TABLE_GROUPS: ReadonlyArray<{ label: string; items: string[] }> = [
-    { label: 'Estructura de Finca', items: ['finca', 'bloque', 'cama', 'grupo_cama', 'seccion'] },
-    { label: 'Variedades', items: ['variedad', 'breeder', 'patron'] },
-    { label: 'Fenología', items: ['estados_fenologicos', 'estado_fenologico_tipo'] },
-    { label: 'Observaciones', items: ['observacion'] },
-    { label: 'Catálogos', items: ['grupo_cama_estado', 'grupo_cama_tipo_planta'] },
-    { label: 'Sistema', items: ['usuario'] },
-]
-
-const RootLayout = () => {
+function RootShell() {
     const currentTitle = useRouterState({
         select: (s) => {
             const match = s.matches.find((m) => m.routeId === '/db/$table') as
@@ -270,127 +24,44 @@ const RootLayout = () => {
         },
     })
 
+    const {
+        query,
+        setQuery,
+        column,
+        setColumn,
+        columns,
+        addFilter,
+        filters,
+        removeFilter,
+        clearFilters,
+    } = useTableFilter()
+
     return (
-        <TableFilterProvider>
-            <SidebarProvider>
-                <div className="flex h-svh w-full overflow-hidden">
-                    <Sidebar>
-                        <SidebarHeader>
-                            <div className="flex items-center justify-between px-2 py-1.5">
-                                <span className="font-semibold">Canavalle</span>
-                            </div>
-                        </SidebarHeader>
-                        <SidebarContent className="gap-0">
-                            <SidebarMenu>
-                                <Collapsible defaultOpen className="group/collapsible">
-                                    <SidebarMenuItem>
-                                        <CollapsibleTrigger asChild>
-                                            <SidebarMenuButton>
-                                                <span>Tablas</span>
-                                                <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
-                                            </SidebarMenuButton>
-                                        </CollapsibleTrigger>
-                                        <CollapsibleContent>
-                                            <SidebarMenuSub>
-                                                {TABLE_GROUPS.map((group) => (
-                                                    <Collapsible key={group.label} defaultOpen className="group/collapsible">
-                                                        <SidebarMenuSubItem>
-                                                            <CollapsibleTrigger asChild>
-                                                                <SidebarMenuSubButton size="sm">
-                                                                    <span>{group.label}</span>
-                                                                    <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
-                                                                </SidebarMenuSubButton>
-                                                            </CollapsibleTrigger>
-                                                            <CollapsibleContent>
-                                                                <SidebarMenuSub className="ml-1">
-                                                                    {group.items
-                                                                        .map((id: string) => TABLES[id])
-                                                                        .filter((t): t is NonNullable<typeof t> => Boolean(t))
-                                                                        .map((t) => (
-                                                                            <SidebarMenuSubItem key={t.id}>
-                                                                                <SidebarMenuSubButton asChild size="sm">
-                                                                                    <Link to="/db/$table" params={{ table: t.id }} activeProps={{ 'data-active': 'true' }}>
-                                                                                        <span>{t.title}</span>
-                                                                                    </Link>
-                                                                                </SidebarMenuSubButton>
-                                                                            </SidebarMenuSubItem>
-                                                                        ))}
-                                                                </SidebarMenuSub>
-                                                            </CollapsibleContent>
-                                                        </SidebarMenuSubItem>
-                                                    </Collapsible>
-                                                ))}
-                                            </SidebarMenuSub>
-                                        </CollapsibleContent>
-                                    </SidebarMenuItem>
-                                </Collapsible>
-                                <Collapsible defaultOpen className="group/collapsible">
-                                    <SidebarMenuItem>
-                                        <CollapsibleTrigger asChild>
-                                            <SidebarMenuButton>
-                                                <span>Resumenes</span>
-                                                <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
-                                            </SidebarMenuButton>
-                                        </CollapsibleTrigger>
-                                        <CollapsibleContent>
-                                            <SidebarMenuSub>
-                                                <SidebarMenuSubItem>
-                                                    <SidebarMenuSubButton asChild size="sm">
-                                                        <Link to="/estimados/area" activeProps={{ 'data-active': 'true' }}>
-                                                            <span>Área productiva por variedad</span>
-                                                        </Link>
-                                                    </SidebarMenuSubButton>
-                                                </SidebarMenuSubItem>
-                                                <SidebarMenuSubItem>
-                                                    <SidebarMenuSubButton asChild size="sm">
-                                                        <Link to="/estimados/observaciones-area" activeProps={{ 'data-active': 'true' }}>
-                                                            <span>Observaciones + área productiva</span>
-                                                        </Link>
-                                                    </SidebarMenuSubButton>
-                                                </SidebarMenuSubItem>
-                                                <SidebarMenuSubItem>
-                                                    <SidebarMenuSubButton asChild size="sm">
-                                                        <Link to={"/estimados/observaciones-resumen" as any} activeProps={{ 'data-active': 'true' }}>
-                                                            <span>Resumen observaciones por cama</span>
-                                                        </Link>
-                                                    </SidebarMenuSubButton>
-                                                </SidebarMenuSubItem>
-                                                <SidebarMenuSubItem>
-                                                    <SidebarMenuSubButton asChild size="sm">
-                                                        <Link to={"/estimados/estimados" as any} activeProps={{ 'data-active': 'true' }}>
-                                                            <span>Estimados</span>
-                                                        </Link>
-                                                    </SidebarMenuSubButton>
-                                                </SidebarMenuSubItem>
-                                                <SidebarMenuSubItem>
-                                                    <SidebarMenuSubButton asChild size="sm">
-                                                        <Link to={"/estimados/estimados-resumen" as any} activeProps={{ 'data-active': 'true' }}>
-                                                            <span>Resumen fenológico (b)</span>
-                                                        </Link>
-                                                    </SidebarMenuSubButton>
-                                                </SidebarMenuSubItem>
-                                            </SidebarMenuSub>
-                                        </CollapsibleContent>
-                                    </SidebarMenuItem>
-                                </Collapsible>
-                            </SidebarMenu>
-                        </SidebarContent>
-                        <SidebarRail />
-                    </Sidebar>
-                    <SidebarInset>
-                        <div className="flex h-12 items-center gap-2 border-b px-2">
-                            <SidebarTrigger />
-                            <div className="font-medium">{currentTitle}</div>
-                            <FilterToolbar />
-                        </div>
-                        <div className="flex-1 min-h-0 min-w-0 overflow-hidden px-4 pb-4">
-                            <Outlet />
-                        </div>
-                    </SidebarInset>
+        <div className="flex h-svh w-full overflow-hidden">
+            <AppSidebar />
+            <SidebarInset>
+                <div className="flex h-12 items-center gap-2 border-b px-2">
+                    <SidebarTrigger />
+                    <div className="font-medium">{currentTitle}</div>
+                    <FilterToolbar
+                        query={query}
+                        setQuery={setQuery}
+                        column={column}
+                        setColumn={setColumn}
+                        columns={columns}
+                        addFilter={addFilter}
+                        filters={filters}
+                        removeFilter={removeFilter}
+                        clearFilters={clearFilters}
+                    />
                 </div>
-            </SidebarProvider>
-        </TableFilterProvider>
+                <div className="flex-1 min-h-0 min-w-0 overflow-hidden px-4 pb-4">
+                    <Outlet />
+                </div>
+            </SidebarInset>
+        </div>
     )
 }
 
 export const Route = createRootRoute({ component: RootLayout })
+


### PR DESCRIPTION
## Summary
- extract the table filter toolbar into `src/features/table-filter/filter-toolbar.tsx` with explicit props from the table filter context
- move sidebar navigation groups into `src/config/navigation.ts` and render them through a reusable `AppSidebar` component
- slim down `src/routes/__root.tsx` so it only composes the providers, sidebar, toolbar, and outlet while exporting the table filter state type for reuse

## Testing
- `npm run lint` *(fails: repository has pre-existing @typescript-eslint/no-explicit-any violations across untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0b5db2b48329ad330ddc816237b3