### PR TITLE
fix lint violations by replacing any usage with typed implementations

### DIFF
--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -2,13 +2,14 @@
 import * as React from 'react'
 import { format } from 'date-fns'
 import { Calendar as CalendarIcon } from 'lucide-react'
+import type { DateRange } from 'react-day-picker'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 
 export type DatePickerValue = Date | undefined
-export type DateRangeValue = { from?: Date; to?: Date }
+export type DateRangeValue = DateRange | undefined
 
 export function DatePicker({ value, onChange, placeholder = 'Seleccionar fecha', className, autoCloseOnSelect, onCommit }: {
     value: DatePickerValue
@@ -69,15 +70,15 @@ export function DateRangePicker({ value, onChange, placeholder = 'Rango de fecha
     onCommit?: () => void
 }) {
     const [open, setOpen] = React.useState(false)
-    const label = value.from && value.to
+    const label = value?.from && value?.to
         ? `${format(value.from, 'dd/MM/yyyy')} – ${format(value.to, 'dd/MM/yyyy')}`
-        : value.from ? format(value.from, 'dd/MM/yyyy') : placeholder
+        : value?.from ? format(value.from, 'dd/MM/yyyy') : placeholder
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
                 <Button
                     variant="outline"
-                    data-empty={!value.from}
+                    data-empty={!value?.from}
                     className={cn('data-[empty=true]:text-muted-foreground w-[220px] justify-start text-left font-normal', className)}
                 >
                     <CalendarIcon className="mr-2 size-4" />
@@ -100,10 +101,10 @@ export function DateRangePicker({ value, onChange, placeholder = 'Rango de fecha
             >
                 <Calendar
                     mode="range"
-                    selected={value as any}
-                    onSelect={(r: any) => {
-                        onChange(r || {})
-                        if (autoCloseOnSelect && r?.from && r?.to) setOpen(false)
+                    selected={value}
+                    onSelect={(range) => {
+                        onChange(range ?? {})
+                        if (autoCloseOnSelect && range?.from && range?.to) setOpen(false)
                     }}
                     numberOfMonths={1}
                 />

--- a/src/config/tables.ts
+++ b/src/config/tables.ts
@@ -1,0 +1,187 @@
+export type TableColumn = {
+  key: string
+  header?: string
+}
+
+export type TableConfig = {
+  id: string
+  title: string
+  columns: TableColumn[]
+}
+
+// Small helper to declare columns without repeating `{ key: '...' }`
+const cols = (...keys: string[]): TableColumn[] => keys.map((key) => ({ key }))
+
+export const TABLES: Record<string, TableConfig> = {
+  finca: {
+    id: 'finca',
+    title: 'Finca',
+    columns: cols(
+      'id_finca',
+      'nombre',
+      // 'creado_en',
+      // 'eliminado_en'
+    ),
+  },
+  bloque: {
+    id: 'bloque',
+    title: 'Bloque',
+    columns: cols(
+      'id_bloque',
+      'finca.nombre',
+      'nombre',
+      'numero_camas',
+      // 'area_m2',
+      // 'creado_en',
+      // 'eliminado_en'
+    ),
+  },
+  grupo_cama: {
+    id: 'grupo_cama',
+    title: 'Grupo cama',
+    columns: cols(
+      'id_grupo',
+      'bloque.nombre',
+      'variedad.nombre',
+      'fecha_siembra',
+      'patron',
+      'estado',
+      'tipo_planta',
+      'numero_camas',
+      'total_plantas',
+      // 'creado_en',
+      // 'eliminado_en',
+    ),
+  },
+  cama: {
+    id: 'cama',
+    title: 'Cama',
+    columns: cols(
+      'id_cama',
+      // 'id_grupo',
+      'finca.nombre',
+      'bloque.nombre',
+      'variedad.nombre',
+      'nombre',
+      'largo_metros',
+      'ancho_metros',
+      // 'plantas_totales',
+      // 'creado_en',
+      // 'eliminado_en',
+    ),
+  },
+  breeder: {
+    id: 'breeder',
+    title: 'Breeder',
+    columns: cols(
+      'id_breeder',
+      'nombre',
+      // 'creado_en',
+      // 'eliminado_en'
+    ),
+  },
+  estado_fenologico_tipo: {
+    id: 'estado_fenologico_tipo',
+    title: 'Estado fenológico tipo',
+    columns: cols(
+      'codigo',
+      // 'creado_en',
+      'orden'
+    ),
+  },
+  estados_fenologicos: {
+    id: 'estados_fenologicos',
+    title: 'Estados fenológicos',
+    columns: cols(
+      'id_estado_fenologico',
+      'id_finca',
+      'id_bloque',
+      'id_variedad',
+      'dias_brotacion',
+      'dias_cincuenta_mm',
+      'dias_quince_cm',
+      'dias_veinte_cm',
+      'dias_primera_hoja',
+      'dias_espiga',
+      'dias_arroz',
+      'dias_arveja',
+      'dias_garbanzo',
+      'dias_uva',
+      'dias_rayando_color',
+      'dias_sepalos_abiertos',
+      'dias_cosecha',
+      // 'creado_en',
+      // 'eliminado_en',
+    ),
+  },
+  grupo_cama_estado: {
+    id: 'grupo_cama_estado',
+    title: 'Grupo cama estado',
+    columns: cols('codigo'),
+  },
+  grupo_cama_tipo_planta: {
+    id: 'grupo_cama_tipo_planta',
+    title: 'Grupo cama tipo planta',
+    columns: cols('codigo'),
+  },
+  observacion: {
+    id: 'observacion',
+    title: 'Observación',
+    columns: cols(
+      // 'id_observacion',
+      'creado_en',
+      'finca.nombre',
+      'bloque.nombre',
+      'variedad.nombre',
+      'cama.nombre',
+      'ubicacion_seccion',
+      'tipo_observacion',
+      'cantidad',
+      'id_usuario',
+      // 'eliminado_en',
+    ),
+  },
+  patron: {
+    id: 'patron',
+    title: 'Patrón',
+    columns: cols(
+      'codigo',
+      // 'proveedor'
+    ),
+  },
+  variedad: {
+    id: 'variedad',
+    title: 'Variedad',
+    columns: cols(
+      'id_variedad',
+      'breeder.nombre',
+      'nombre',
+      // 'creado_en',
+      // 'eliminado_en',
+      'color'
+    ),
+  },
+  usuario: {
+    id: 'usuario',
+    title: 'Usuario',
+    columns: cols('id_usuario', 'creado_en', 'nombres', 'apellidos', 'rol', 'clave_pin'),
+  },
+  seccion: {
+    id: 'seccion',
+    title: 'Sección',
+    columns: cols('largo_m'),
+  },
+}
+
+export function getTableConfig(id: string): TableConfig | undefined {
+  return TABLES[id]
+}
+
+export const TABLE_GROUPS: ReadonlyArray<{ label: string; items: string[] }> = [
+  { label: 'Estructura de Finca', items: ['finca', 'bloque', 'cama', 'grupo_cama', 'seccion'] },
+  { label: 'Variedades', items: ['variedad', 'breeder', 'patron'] },
+  { label: 'Fenología', items: ['estados_fenologicos', 'estado_fenologico_tipo'] },
+  { label: 'Observaciones', items: ['observacion'] },
+  { label: 'Catálogos', items: ['grupo_cama_estado', 'grupo_cama_tipo_planta'] },
+  { label: 'Sistema', items: ['usuario'] },
+]

--- a/src/hooks/use-deferred-live-query.ts
+++ b/src/hooks/use-deferred-live-query.ts
@@ -8,11 +8,11 @@ import { useLiveQuery } from 'dexie-react-hooks'
  */
 export function useDeferredLiveQuery<T>(
     fn: () => Promise<T>,
-    deps: any[],
+    deps: React.DependencyList,
     options?: { delay?: number; defer?: boolean }
 ) {
     const { delay = 80, defer = true } = options || {}
-    const data = useLiveQuery(fn, deps) as T | undefined
+    const data = useLiveQuery<T | undefined>(fn, deps)
     const [showSkeleton, setShowSkeleton] = React.useState(true)
     React.useEffect(() => {
         if (data !== undefined) {

--- a/src/hooks/use-dotted-lookups.ts
+++ b/src/hooks/use-dotted-lookups.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useLiveQuery } from 'dexie-react-hooks'
-import { getStore } from '@/lib/dexie'
+import { getStore, type AnyRow } from '@/lib/dexie'
 import { SERVICE_PK } from '@/services/db'
 
 // Given columns that may contain dotted keys like `finca.nombre` and the base rows,
@@ -8,6 +8,22 @@ import { SERVICE_PK } from '@/services/db'
 // a derived `displayRows` where dotted keys are added as flattened properties for rendering.
 
 export type Column = { key: string; header?: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null
+}
+
+function asId(value: unknown): string | number | undefined {
+    if (typeof value === 'string' || typeof value === 'number') return value
+    return undefined
+}
+
+function getNestedValue(source: AnyRow | undefined, path: string[]): unknown {
+    return path.reduce<unknown>((acc, key) => {
+        if (!isRecord(acc)) return undefined
+        return acc[key]
+    }, source as unknown)
+}
 
 function getRelatedFromColumns(columns: Column[]): string[] {
     const rels = new Set<string>()
@@ -20,51 +36,47 @@ function getRelatedFromColumns(columns: Column[]): string[] {
     return Array.from(rels)
 }
 
-export function useDottedLookups(tableId: string, rows: any[], columns: Column[], options?: { requireAll?: boolean }) {
+const RELATION_PATHS: Record<string, Record<string, Array<{ fk: string; table: string }>>> = {
+    cama: {
+        variedad: [
+            { fk: 'id_grupo', table: 'grupo_cama' },
+            { fk: 'id_variedad', table: 'variedad' },
+        ],
+        bloque: [
+            { fk: 'id_grupo', table: 'grupo_cama' },
+            { fk: 'id_bloque', table: 'bloque' },
+        ],
+        finca: [
+            { fk: 'id_grupo', table: 'grupo_cama' },
+            { fk: 'id_bloque', table: 'bloque' },
+            { fk: 'id_finca', table: 'finca' },
+        ],
+    },
+    observacion: {
+        variedad: [
+            { fk: 'id_cama', table: 'cama' },
+            { fk: 'id_grupo', table: 'grupo_cama' },
+            { fk: 'id_variedad', table: 'variedad' },
+        ],
+        bloque: [
+            { fk: 'id_cama', table: 'cama' },
+            { fk: 'id_grupo', table: 'grupo_cama' },
+            { fk: 'id_bloque', table: 'bloque' },
+        ],
+        finca: [
+            { fk: 'id_cama', table: 'cama' },
+            { fk: 'id_grupo', table: 'grupo_cama' },
+            { fk: 'id_bloque', table: 'bloque' },
+            { fk: 'id_finca', table: 'finca' },
+        ],
+    },
+}
+
+export function useDottedLookups(tableId: string, rows: AnyRow[], columns: Column[], options?: { requireAll?: boolean }) {
     const requireAll = options?.requireAll !== false // default true
     const related = getRelatedFromColumns(columns)
 
-    // Multi-hop relation paths for special cases.
-    // Each entry defines how to resolve a top-level relation name from the base table rows.
-    // For example for table 'cama', to resolve 'finca', go through:
-    //   id_grupo -> grupo_cama -> id_bloque -> bloque -> id_finca -> finca
-    const RELATION_PATHS: Record<string, Record<string, Array<{ fk: string; table: string }>>> = {
-        cama: {
-            variedad: [
-                { fk: 'id_grupo', table: 'grupo_cama' },
-                { fk: 'id_variedad', table: 'variedad' },
-            ],
-            bloque: [
-                { fk: 'id_grupo', table: 'grupo_cama' },
-                { fk: 'id_bloque', table: 'bloque' },
-            ],
-            finca: [
-                { fk: 'id_grupo', table: 'grupo_cama' },
-                { fk: 'id_bloque', table: 'bloque' },
-                { fk: 'id_finca', table: 'finca' },
-            ],
-        },
-        observacion: {
-            variedad: [
-                { fk: 'id_cama', table: 'cama' },
-                { fk: 'id_grupo', table: 'grupo_cama' },
-                { fk: 'id_variedad', table: 'variedad' },
-            ],
-            bloque: [
-                { fk: 'id_cama', table: 'cama' },
-                { fk: 'id_grupo', table: 'grupo_cama' },
-                { fk: 'id_bloque', table: 'bloque' },
-            ],
-            finca: [
-                { fk: 'id_cama', table: 'cama' },
-                { fk: 'id_grupo', table: 'grupo_cama' },
-                { fk: 'id_bloque', table: 'bloque' },
-                { fk: 'id_finca', table: 'finca' },
-            ],
-        },
-    }
-
-    type RelLookup = { mapByRelatedId?: Map<string | number, any>; mapByBasePk?: Map<string | number, any> }
+    type RelLookup = { mapByRelatedId?: Map<string | number, AnyRow>; mapByBasePk?: Map<string | number, AnyRow | undefined> }
 
     // Build lookups for each relation name (rel) using FK id_<rel>
     const lookups = useLiveQuery(async () => {
@@ -77,35 +89,38 @@ export function useDottedLookups(tableId: string, rows: any[], columns: Column[]
             if (customPath && basePkKey) {
                 // Multi-hop: build Map basePk -> final related row
                 // Step 0: start from base rows
-                let baseToCurrent = new Map<string | number, any>()
+                let baseToCurrent = new Map<string | number, AnyRow | undefined>()
                 for (const row of rows) {
                     const basePk = row?.[basePkKey]
-                    if (basePk == null) continue
-                    baseToCurrent.set(basePk as string | number, row)
+                    const id = asId(basePk)
+                    if (id === undefined) continue
+                    baseToCurrent.set(id, row)
                 }
 
                 // Traverse steps
                 for (const step of customPath) {
-                    const ids = Array.from(new Set(
-                        Array.from(baseToCurrent.values())
-                            .map((r: any) => r?.[step.fk])
-                            .filter((v) => v != null)
-                    ))
+                    const ids = Array.from(
+                        new Set(
+                            Array.from(baseToCurrent.values())
+                                .map((r) => (isRecord(r) ? asId(r[step.fk]) : undefined))
+                                .filter((v): v is string | number => v !== undefined)
+                        )
+                    )
                     const nextStore = getStore(step.table)
                     const recs = await nextStore.bulkGet(ids)
                     // index recs by that table's PK
                     const tablePk = SERVICE_PK[step.table]
-                    const idx = new Map<string | number, any>()
+                    const idx = new Map<string | number, AnyRow>()
                     for (const rec of recs) {
-                        if (!rec) continue
-                        const id = (rec as any)[tablePk]
-                        if (id != null) idx.set(id as string | number, rec)
+                        if (!rec || !tablePk) continue
+                        const id = asId(rec[tablePk])
+                        if (id !== undefined) idx.set(id, rec)
                     }
                     // produce new mapping: basePk -> nextRow
-                    const updated = new Map<string | number, any>()
+                    const updated = new Map<string | number, AnyRow | undefined>()
                     for (const [basePk, cur] of baseToCurrent.entries()) {
-                        const nextId = cur?.[step.fk]
-                        const nextRow = nextId != null ? idx.get(nextId as string | number) : undefined
+                        const nextId = isRecord(cur) ? asId(cur[step.fk]) : undefined
+                        const nextRow = nextId !== undefined ? idx.get(nextId) : undefined
                         updated.set(basePk, nextRow)
                     }
                     baseToCurrent = updated
@@ -117,7 +132,13 @@ export function useDottedLookups(tableId: string, rows: any[], columns: Column[]
 
             // Single hop default: id_<rel> on base rows
             const fk = `id_${rel}`
-            const ids = Array.from(new Set(rows.map((r) => r?.[fk]).filter((v) => v != null)))
+            const ids = Array.from(
+                new Set(
+                    rows
+                        .map((r) => asId(r?.[fk]))
+                        .filter((v): v is string | number => v !== undefined)
+                )
+            )
             if (ids.length === 0) {
                 out[rel] = { mapByRelatedId: new Map() }
                 continue
@@ -125,15 +146,16 @@ export function useDottedLookups(tableId: string, rows: any[], columns: Column[]
             try {
                 const store = getStore(rel)
                 const recs = await store.bulkGet(ids)
-                const m = new Map<string | number, any>()
+                const m = new Map<string | number, AnyRow>()
                 const pkKey = SERVICE_PK[rel] ?? `id_${rel}`
                 for (const rec of recs) {
                     if (!rec) continue
-                    const id = (rec as any)[pkKey] ?? (rec as any)['id']
-                    if (id != null) m.set(id as string | number, rec)
+                    const rawId = rec[pkKey] ?? rec['id']
+                    const id = asId(rawId)
+                    if (id !== undefined) m.set(id, rec)
                 }
                 out[rel] = { mapByRelatedId: m }
-            } catch (e) {
+            } catch {
                 out[rel] = { mapByRelatedId: new Map() }
             }
         }
@@ -156,17 +178,17 @@ export function useDottedLookups(tableId: string, rows: any[], columns: Column[]
                 // For multi-hop, if any base row has a non-null final mapping undefined -> still loading
                 for (const row of rows || []) {
                     const basePk = row?.[basePkKeyInner]
-                    if (basePk == null) continue
+                    const id = asId(basePk)
+                    if (id === undefined) continue
                     if (!lookups[rel]) { relationLoading = true; break outer }
-                    if (lookups[rel].mapByBasePk?.has(basePk)) {
-                        const val = lookups[rel].mapByBasePk?.get(basePk)
+                    if (lookups[rel].mapByBasePk?.has(id)) {
+                        const val = lookups[rel].mapByBasePk?.get(id)
                         // allow undefined if intermediate was genuinely missing (no fk); only treat as loading if fk chain exists
                         // We approximate by checking each step's fk presence.
                         let chainOk = true
-                        let cur: any = row
                         for (const step of customPath) {
-                            const idVal = cur?.[step.fk]
-                            if (idVal == null) { chainOk = false; break }
+                            const idVal = row ? asId(row[step.fk]) : undefined
+                            if (idVal === undefined) { chainOk = false; break }
                             // fetch record quickly (can't synchronously, rely on earlier map)
                         }
                         if (chainOk && val === undefined) { relationLoading = true; break outer }
@@ -177,38 +199,41 @@ export function useDottedLookups(tableId: string, rows: any[], columns: Column[]
                 const fk = `id_${rel}`
                 for (const row of rows || []) {
                     const relId = row?.[fk]
-                    if (relId == null) continue
+                    const idVal = asId(relId)
+                    if (idVal === undefined) continue
                     const lk = lookups[rel]
                     if (!lk) { relationLoading = true; break outer }
-                    const has = lk.mapByRelatedId?.has(relId as any)
+                    const has = lk.mapByRelatedId?.has(idVal)
                     if (!has) { relationLoading = true; break outer }
                 }
             }
         }
     }
 
-    const displayRows = React.useMemo(() => {
+    const displayRows = React.useMemo<AnyRow[]>(() => {
         if (relationLoading || !lookups) return []
         return (rows ?? []).map((row) => {
-            let acc = row
+            let acc: AnyRow = row
             for (const c of columns) {
                 const key = c.key
                 if (typeof key !== 'string' || !key.includes('.')) continue
                 const [rel, ...rest] = key.split('.')
                 const relLookup = lookups[rel]
                 if (!relLookup) continue
-                let relRow: any
+                let relRow: AnyRow | undefined
                 const customPath = (RELATION_PATHS[tableId] || {})[rel]
                 const basePkKeyInner = SERVICE_PK[tableId]
                 if (customPath && basePkKeyInner) {
                     const basePk = row?.[basePkKeyInner]
-                    relRow = basePk != null ? relLookup.mapByBasePk?.get(basePk as string | number) : undefined
+                    const id = asId(basePk)
+                    relRow = id !== undefined ? relLookup.mapByBasePk?.get(id) : undefined
                 } else {
                     const fk = `id_${rel}`
                     const relId = row?.[fk]
-                    relRow = relId != null ? relLookup.mapByRelatedId?.get(relId as string | number) : undefined
+                    const id = asId(relId)
+                    relRow = id !== undefined ? relLookup.mapByRelatedId?.get(id) : undefined
                 }
-                const value = rest.reduce<any>((a, k) => (a == null ? a : a[k]), relRow)
+                const value = getNestedValue(relRow, rest)
                 acc = { ...acc, [key]: value }
             }
             return acc

--- a/src/hooks/use-table-filter.tsx
+++ b/src/hooks/use-table-filter.tsx
@@ -51,7 +51,7 @@ export const TableFilterProvider: React.FC<{ children: React.ReactNode }> = ({ c
             setQuery('')
             setColumn('*')
             setFilters([])
-            return cols.map(c => ({ ...c, type: c.type ?? inferType(c.key) }))
+            return cols.map((c) => ({ ...c, type: c.type ?? inferType(c.key) }))
         })
     }, [])
 
@@ -98,13 +98,15 @@ export function useTableFilter() {
 }
 
 // Helper to apply filtering to a row list; can be used if needed elsewhere
-export function useFilteredRows<T extends Record<string, any>>(rows: T[] | null | undefined, columns: { key: keyof T; header?: string }[]) {
+export function useFilteredRows<T extends Record<string, unknown>>(rows: T[] | null | undefined, columns: { key: keyof T; header?: string }[]) {
     const { query, column } = useTableFilter()
     return React.useMemo(() => {
         if (!rows || !rows.length) return rows ?? []
         if (!query) return rows
         const q = query.toLowerCase()
-        const keys: string[] = column === '*' ? columns.map((c) => c.key as string) : [column]
+        const keys: Array<keyof T> = column === '*'
+            ? columns.map((c) => c.key)
+            : [column as keyof T]
         return rows.filter((row) => {
             return keys.some((k) => {
                 const v = row?.[k]

--- a/src/lib/dexie.ts
+++ b/src/lib/dexie.ts
@@ -1,14 +1,10 @@
-import Dexie, { Table } from 'dexie'
+import Dexie, { type Table } from 'dexie'
 
 // Define a minimal row shape: all values are unknown, but rows must have a PK
 export type AnyRow = Record<string, unknown>
 
 // Names of our stores correspond to table names (keys of SERVICE_PK and TABLES)
 export class AppDexie extends Dexie {
-    // Dynamic table index: [tableName: string]: Table<AnyRow, any>
-    // We'll also add typed properties at runtime.
-    [storeName: string]: any
-
     constructor() {
         super('canavalle-db')
         // Stores are defined later via initDexieSchema()
@@ -42,6 +38,6 @@ export async function initDexieSchema() {
     }
 }
 
-export function getStore(table: string): Table<AnyRow, any> {
-    return (db as any)[table] as Table<AnyRow, any>
+export function getStore(table: string): Table<AnyRow, string> {
+    return db.table<AnyRow, string>(table)
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,10 +7,20 @@ export function cn(...inputs: ClassValue[]) {
 
 // --- Date formatting helpers ---
 // Display format requested: DD/MM/YYYY (always using UTC components to avoid TZ drift)
-export function formatDate(value: any): string {
-  if (!value) return ''
-  const d = new Date(value)
-  if (isNaN(d.getTime())) return ''
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const d = new Date(value)
+    return Number.isNaN(d.getTime()) ? null : d
+  }
+  return null
+}
+
+export function formatDate(value: unknown): string {
+  const d = toDate(value)
+  if (!d) return ''
   const y = d.getUTCFullYear()
   const m = String(d.getUTCMonth() + 1).padStart(2, '0')
   const day = String(d.getUTCDate()).padStart(2, '0')
@@ -18,17 +28,16 @@ export function formatDate(value: any): string {
 }
 
 // Canonical ISO (YYYY-MM-DD) if ever needed for stable lexical sorting
-export function formatDateISO(value: any): string {
-  if (!value) return ''
-  const d = new Date(value)
-  if (isNaN(d.getTime())) return ''
+export function formatDateISO(value: unknown): string {
+  const d = toDate(value)
+  if (!d) return ''
   const y = d.getUTCFullYear()
   const m = String(d.getUTCMonth() + 1).padStart(2, '0')
   const day = String(d.getUTCDate()).padStart(2, '0')
   return `${y}-${m}-${day}`
 }
 
-export function formatDateRange(from?: any, to?: any): string {
+export function formatDateRange(from?: unknown, to?: unknown): string {
   const aISO = formatDateISO(from)
   const bISO = formatDateISO(to)
   if (!aISO && !bISO) return ''

--- a/src/routes/estimados/estimados.tsx
+++ b/src/routes/estimados/estimados.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 import { useDeferredLiveQuery } from '@/hooks/use-deferred-live-query'
-import { getStore } from '@/lib/dexie'
-import { DataTable } from '@/components/data-table'
+import { getStore, type AnyRow } from '@/lib/dexie'
+import { DataTable, type Column } from '@/components/data-table'
 import { DataTableSkeleton } from '@/components/data-table-skeleton'
 import { formatDate } from '@/lib/utils'
 import { supabase } from '@/lib/supabase'
 
-export const Route = createFileRoute('/estimados/estimados' as any)({
+export const Route = createFileRoute('/estimados/estimados')({
   component: Page,
 })
 
@@ -32,7 +32,7 @@ type Row = {
 
 function Page() {
   const { data, loading } = useDeferredLiveQuery<Row[] | undefined>(async () => {
-    const parseNumber = (val: any): number => {
+    const parseNumber = (val: unknown): number => {
       if (typeof val === 'number') return isFinite(val) ? val : 0
       if (typeof val === 'string') {
         const s = val.trim()
@@ -49,7 +49,14 @@ function Page() {
       return 0
     }
 
-    const [observaciones, camas, grupos, bloques, fincas, variedades] = await Promise.all([
+    const [observaciones, camas, grupos, bloques, fincas, variedades] = await Promise.all<[
+      AnyRow[],
+      AnyRow[],
+      AnyRow[],
+      AnyRow[],
+      AnyRow[],
+      AnyRow[],
+    ]>([
       getStore('observacion').toArray(),
       getStore('cama').toArray(),
       getStore('grupo_cama').toArray(),
@@ -62,64 +69,68 @@ function Page() {
     let seccionLargoM = 0
     try {
       const secciones = await getStore('seccion').toArray()
-      if (secciones && secciones.length > 0) {
-        const s0: any = (secciones as any[])[0]
-        seccionLargoM = Number(s0?.largo_m) || 0
+      if (secciones.length > 0) {
+        const s0 = secciones[0]
+        seccionLargoM = Number(s0?.['largo_m']) || 0
       }
     } catch {
       const { data: secData } = await supabase.from('seccion').select('largo_m').limit(1)
-      if (secData && secData.length > 0) {
-        const s0: any = (secData as any[])[0]
-        seccionLargoM = Number(s0?.largo_m) || 0
+      if (Array.isArray(secData) && secData.length > 0) {
+        const s0 = secData[0] as AnyRow
+        seccionLargoM = Number(s0?.['largo_m']) || 0
       }
     }
 
-    const mapBy = <T extends Record<string, any>>(arr: T[], key: string) => {
+    const mapBy = <T extends Record<string, unknown>>(arr: T[], key: string) => {
       const m = new Map<string, T>()
-      for (const it of arr) m.set(String(it[key]), it)
+      for (const it of arr) {
+        const id = it?.[key]
+        if (id == null) continue
+        m.set(String(id), it)
+      }
       return m
     }
 
-    const camasById = mapBy(camas as any[], 'id_cama')
-    const gruposById = mapBy(grupos as any[], 'id_grupo')
-    const bloquesById = mapBy(bloques as any[], 'id_bloque')
-    const fincasById = mapBy(fincas as any[], 'id_finca')
-    const variedadesById = mapBy(variedades as any[], 'id_variedad')
+    const camasById = mapBy(camas, 'id_cama')
+    const gruposById = mapBy(grupos, 'id_grupo')
+    const bloquesById = mapBy(bloques, 'id_bloque')
+    const fincasById = mapBy(fincas, 'id_finca')
+    const variedadesById = mapBy(variedades, 'id_variedad')
 
     // Precompute area productiva per (bloque,variedad) across productivo grupos
     const ESTADO_PRODUCTIVO = 'productivo'
     const areaByBloqueVar = new Map<string, number>()
-    for (const c of camas as any[]) {
-      const g = gruposById.get(String((c as any).id_grupo))
+    for (const cama of camas) {
+      const g = gruposById.get(String(cama?.['id_grupo']))
       if (!g) continue
-      const estado = String((g as any).estado ?? '').toLowerCase()
+      const estado = String(g?.['estado'] ?? '').toLowerCase()
       if (estado !== ESTADO_PRODUCTIVO) continue
-      const key = `${String((g as any).id_bloque)}|${String((g as any).id_variedad)}`
-      const largo = Number((c as any).largo_metros) || 0
-      const ancho = Number((c as any).ancho_metros) || 0
+      const key = `${String(g?.['id_bloque'])}|${String(g?.['id_variedad'])}`
+      const largo = Number(cama?.['largo_metros']) || 0
+      const ancho = Number(cama?.['ancho_metros']) || 0
       const area = largo * ancho
       areaByBloqueVar.set(key, (areaByBloqueVar.get(key) || 0) + area)
     }
 
     // Group by (id_cama, tipo_observacion)
     const acc = new Map<string, Row>()
-    for (const o of (observaciones as any[])) {
-      const idCama = String(o?.id_cama ?? '')
+    for (const o of observaciones) {
+      const idCama = o?.['id_cama'] != null ? String(o['id_cama']) : ''
       if (!idCama) continue
       const cama = camasById.get(idCama)
       if (!cama) continue
-      const ancho = Number((cama as any)?.ancho_metros) || 0
-      const largo = Number((cama as any)?.largo_metros) || 0
+      const ancho = Number(cama?.['ancho_metros']) || 0
+      const largo = Number(cama?.['largo_metros']) || 0
       const areaCama = largo * ancho
       const areaObs = (Number(seccionLargoM) || 0) * ancho
-      const cant = parseNumber((o as any)?.cantidad)
-      const g = gruposById.get(String((cama as any)?.id_grupo))
-      const b = g ? bloquesById.get(String((g as any)?.id_bloque)) : undefined
-      const f = b ? fincasById.get(String((b as any)?.id_finca)) : undefined
-      const v = g ? variedadesById.get(String((g as any)?.id_variedad)) : undefined
-      const tipo = String(o?.tipo_observacion ?? '')
+      const cant = parseNumber(o?.['cantidad'])
+      const g = gruposById.get(String(cama?.['id_grupo']))
+      const b = g ? bloquesById.get(String(g?.['id_bloque'])) : undefined
+      const f = b ? fincasById.get(String(b?.['id_finca'])) : undefined
+      const v = g ? variedadesById.get(String(g?.['id_variedad'])) : undefined
+      const tipo = String(o?.['tipo_observacion'] ?? '')
       const key = `${idCama}|${tipo}`
-      const gKey = g ? `${String((g as any).id_bloque)}|${String((g as any).id_variedad)}` : 'x|x'
+      const gKey = g ? `${String(g?.['id_bloque'])}|${String(g?.['id_variedad'])}` : 'x|x'
       const areaProductiva = g ? (areaByBloqueVar.get(gKey) || 0) : 0
       const existing = acc.get(key)
       if (existing) {
@@ -127,19 +138,19 @@ function Page() {
         existing.area_observada += areaObs
         // Keep latest date
         const prev = existing.fecha ? new Date(existing.fecha) : null
-        const curRaw: any = (o as any)?.creado_en ?? (o as any)?.fecha ?? null
+        const curRaw = (o?.['creado_en'] ?? o?.['fecha']) ?? null
         const cur = curRaw ? new Date(curRaw) : null
         if (cur && (!prev || cur > prev)) existing.fecha = cur.toISOString()
       } else {
         acc.set(key, {
-          id_cama: (cama as any)?.id_cama,
-          cama: String((cama as any)?.nombre ?? ''),
-          bloque: String((b as any)?.nombre ?? ''),
-          finca: String((f as any)?.nombre ?? ''),
-          variedad: String((v as any)?.nombre ?? ''),
+          id_cama: cama?.['id_cama'] as string | number,
+          cama: String(cama?.['nombre'] ?? ''),
+          bloque: String(b?.['nombre'] ?? ''),
+          finca: String(f?.['nombre'] ?? ''),
+          variedad: String(v?.['nombre'] ?? ''),
           tipo_observacion: tipo,
           fecha: (() => {
-            const raw: any = (o as any)?.creado_en ?? (o as any)?.fecha ?? null
+            const raw = (o?.['creado_en'] ?? o?.['fecha']) ?? null
             if (!raw) return null
             const d = new Date(raw)
             return isNaN(d.getTime()) ? String(raw) : d.toISOString()
@@ -158,14 +169,16 @@ function Page() {
     }
 
     // finalize derived fields
-    const rows = Array.from(acc.values()).map((r) => {
-      const densidad = r.area_observada > 0 ? r.cantidad_total / r.area_observada : 0
-      const estimado_cama = densidad * r.area_cama
-      const estimado_bloque = densidad * r.area_productiva
-      const densidad_b = r.area_cama > 0 ? r.cantidad_total / r.area_cama : 0
-      const estimado_bloque_b = densidad_b * r.area_productiva
-      return { ...r, densidad, estimado_cama, estimado_bloque, densidad_b, estimado_bloque_b }
-    }).sort((a, b) =>
+    const rows = Array.from(acc.values())
+      .map((r) => {
+        const densidad = r.area_observada > 0 ? r.cantidad_total / r.area_observada : 0
+        const estimado_cama = densidad * r.area_cama
+        const estimado_bloque = densidad * r.area_productiva
+        const densidad_b = r.area_cama > 0 ? r.cantidad_total / r.area_cama : 0
+        const estimado_bloque_b = densidad_b * r.area_productiva
+        return { ...r, densidad, estimado_cama, estimado_bloque, densidad_b, estimado_bloque_b }
+      })
+      .sort((a, b) =>
       a.finca.localeCompare(b.finca, undefined, { sensitivity: 'base' }) ||
       a.bloque.localeCompare(b.bloque, undefined, { sensitivity: 'base' }) ||
       a.variedad.localeCompare(b.variedad, undefined, { sensitivity: 'base' }) ||
@@ -173,33 +186,38 @@ function Page() {
       a.tipo_observacion.localeCompare(b.tipo_observacion, undefined, { sensitivity: 'base' })
     )
 
-    return rows as Row[]
+    return rows
   }, [], { defer: false })
 
-  const fmt = (v: number) => (Number(v || 0)).toLocaleString(undefined, { maximumFractionDigits: 2 })
-  const columns = React.useMemo(() => ([
-    { key: 'finca', header: 'Finca' },
-    { key: 'bloque', header: 'Bloque' },
-    { key: 'variedad', header: 'Variedad' },
-    { key: 'cama', header: 'Cama' },
-    { key: 'tipo_observacion', header: 'Estado fenológico' },
-    { key: 'fecha', header: 'Fecha', render: (v: any) => formatDate(v) },
-    { key: 'cantidad_total', header: 'Cantidad' },
-    { key: 'area_observada', header: 'Área observada (m²)', render: (v: number) => fmt(v) },
-    { key: 'area_cama', header: 'Área cama (m²)', render: (v: number) => fmt(v) },
-    { key: 'area_productiva', header: 'Área productiva (m²)', render: (v: number) => fmt(v) },
-    { key: 'densidad', header: 'Densidad (/m²)', render: (v: number) => fmt(v) },
-    { key: 'estimado_cama', header: 'Estimado cama (a)', render: (v: number) => fmt(v) },
-    { key: 'estimado_bloque', header: 'Estimado bloque (a)', render: (v: number) => fmt(v) },
-    { key: 'densidad_b', header: 'Densidad B (/m²)', render: (v: number) => fmt(v) },
-    { key: 'estimado_bloque_b', header: 'Estimado bloque (b)', render: (v: number) => fmt(v) },
-  ]), []) as any
+  const fmt = (value: unknown) => (Number(value ?? 0)).toLocaleString(undefined, { maximumFractionDigits: 2 })
+  const columns = React.useMemo<Column<Row>[]>(
+    () => [
+      { key: 'finca', header: 'Finca' },
+      { key: 'bloque', header: 'Bloque' },
+      { key: 'variedad', header: 'Variedad' },
+      { key: 'cama', header: 'Cama' },
+      { key: 'tipo_observacion', header: 'Estado fenológico' },
+      { key: 'fecha', header: 'Fecha', render: (value) => formatDate(value) },
+      { key: 'cantidad_total', header: 'Cantidad' },
+      { key: 'area_observada', header: 'Área observada (m²)', render: (value) => fmt(value) },
+      { key: 'area_cama', header: 'Área cama (m²)', render: (value) => fmt(value) },
+      { key: 'area_productiva', header: 'Área productiva (m²)', render: (value) => fmt(value) },
+      { key: 'densidad', header: 'Densidad (/m²)', render: (value) => fmt(value) },
+      { key: 'estimado_cama', header: 'Estimado cama (a)', render: (value) => fmt(value) },
+      { key: 'estimado_bloque', header: 'Estimado bloque (a)', render: (value) => fmt(value) },
+      { key: 'densidad_b', header: 'Densidad B (/m²)', render: (value) => fmt(value) },
+      { key: 'estimado_bloque_b', header: 'Estimado bloque (b)', render: (value) => fmt(value) },
+    ],
+    [],
+  )
+
+  const skeletonColumns = React.useMemo(() => columns.map((c) => ({ key: String(c.key), header: c.header })), [columns])
 
   return (
     <div className="h-full min-h-0 min-w-0 flex flex-col overflow-hidden">
-      {loading && <DataTableSkeleton columns={columns as any} rows={8} />}
+      {loading && <DataTableSkeleton columns={skeletonColumns} rows={8} />}
       {!loading && (
-        <DataTable<Row> caption={`${(data || []).length}`} columns={columns} rows={data || []} />
+        <DataTable caption={`${(data || []).length}`} columns={columns} rows={data || []} />
       )}
     </div>
   )

--- a/src/routes/estimados/observaciones-area.tsx
+++ b/src/routes/estimados/observaciones-area.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 import { useDeferredLiveQuery } from '@/hooks/use-deferred-live-query'
-import { getStore } from '@/lib/dexie'
+import { getStore, type AnyRow } from '@/lib/dexie'
 import { DataTable } from '@/components/data-table'
 import { DataTableSkeleton } from '@/components/data-table-skeleton'
 import { formatDate } from '@/lib/utils'
-import { getTableConfig } from '@/services/db'
+import { getTableConfig } from '@/config/tables'
 import { useDottedLookups } from '@/hooks/use-dotted-lookups'
 import { supabase } from '@/lib/supabase'
 
@@ -17,8 +17,12 @@ const ESTADO_PRODUCTIVO = 'productivo'
 
 function Page() {
   // Load base data
-  const { data, loading } = useDeferredLiveQuery<any[] | undefined>(async () => {
-    const [observaciones, camas, grupos] = await Promise.all([
+  const { data, loading } = useDeferredLiveQuery<AnyRow[] | undefined>(async () => {
+    const [observaciones, camas, grupos] = await Promise.all<[
+      AnyRow[],
+      AnyRow[],
+      AnyRow[],
+    ]>([
       getStore('observacion').toArray(),
       getStore('cama').toArray(),
       getStore('grupo_cama').toArray(),
@@ -28,78 +32,94 @@ function Page() {
     let seccionLargoM = 0
     try {
       const secciones = await getStore('seccion').toArray()
-      if (secciones && secciones.length > 0) {
-        const s0: any = (secciones as any[])[0]
-        seccionLargoM = Number(s0?.largo_m) || 0
+      if (secciones.length > 0) {
+        const s0 = secciones[0]
+        seccionLargoM = Number(s0?.['largo_m']) || 0
       }
     } catch {
       const { data: secData } = await supabase.from('seccion').select('largo_m').limit(1)
-      if (secData && secData.length > 0) {
-        const s0: any = (secData as any[])[0]
-        seccionLargoM = Number(s0?.largo_m) || 0
+      if (Array.isArray(secData) && secData.length > 0) {
+        const s0 = secData[0] as AnyRow
+        seccionLargoM = Number(s0?.['largo_m']) || 0
       }
     }
 
-    const mapBy = <T extends Record<string, any>>(arr: T[], key: string) => {
+    const mapBy = <T extends Record<string, unknown>>(arr: T[], key: string) => {
       const m = new Map<string, T>()
-      for (const it of arr) m.set(String(it[key]), it)
+      for (const it of arr) {
+        const id = it?.[key]
+        if (id == null) continue
+        m.set(String(id), it)
+      }
       return m
     }
 
-    const gruposById = mapBy(grupos as any[], 'id_grupo')
-    const camasById = mapBy(camas as any[], 'id_cama')
+    const gruposById = mapBy(grupos, 'id_grupo')
+    const camasById = mapBy(camas, 'id_cama')
 
     // Precompute area per (bloque,variedad) across productivo grupos
     const areaByBloqueVar = new Map<string, number>()
-    for (const c of camas as any[]) {
-      const g = gruposById.get(String(c.id_grupo))
+    for (const cama of camas) {
+      const g = gruposById.get(String(cama?.['id_grupo']))
       if (!g) continue
-      if ((g.estado ?? '').toString().toLowerCase() !== ESTADO_PRODUCTIVO) continue
-      const key = `${String(g.id_bloque)}|${String(g.id_variedad)}`
-      const largo = Number(c.largo_metros) || 0
-      const ancho = Number(c.ancho_metros) || 0
+      const estado = String(g?.['estado'] ?? '').toLowerCase()
+      if (estado !== ESTADO_PRODUCTIVO) continue
+      const key = `${String(g?.['id_bloque'])}|${String(g?.['id_variedad'])}`
+      const largo = Number(cama?.['largo_metros']) || 0
+      const ancho = Number(cama?.['ancho_metros']) || 0
       const area = largo * ancho
       areaByBloqueVar.set(key, (areaByBloqueVar.get(key) || 0) + area)
     }
 
     // Augment each observación with area_productiva for its bloque/variedad
     // and area_cama computed from the linked cama (largo_metros * ancho_metros)
-    const augmented = (observaciones as any[]).map((o) => {
-      const cama = o?.id_cama != null ? camasById.get(String(o.id_cama)) : undefined
-      const g = cama ? gruposById.get(String(cama.id_grupo)) : undefined
-      const key = g ? `${String(g.id_bloque)}|${String(g.id_variedad)}` : 'x|x'
+    const augmented = observaciones.map((o) => {
+      const cama = o?.['id_cama'] != null ? camasById.get(String(o['id_cama'])) : undefined
+      const g = cama ? gruposById.get(String(cama?.['id_grupo'])) : undefined
+      const key = g ? `${String(g?.['id_bloque'])}|${String(g?.['id_variedad'])}` : 'x|x'
       const area_productiva = g ? (areaByBloqueVar.get(key) || 0) : 0
-      const largo = Number((cama as any)?.largo_metros) || 0
-      const ancho = Number((cama as any)?.ancho_metros) || 0
+      const largo = Number(cama?.['largo_metros']) || 0
+      const ancho = Number(cama?.['ancho_metros']) || 0
       const area_cama = largo * ancho
-      const area_observacion = (Number(seccionLargoM) || 0) * (Number((cama as any)?.ancho_metros) || 0)
-      const fecha = (o as any)?.creado_en ?? (o as any)?.fecha ?? null
-      return { ...o, fecha, area_productiva, area_cama, area_observacion }
+      const area_observacion = (Number(seccionLargoM) || 0) * (Number(cama?.['ancho_metros']) || 0)
+      const fecha = (o?.['creado_en'] ?? o?.['fecha']) ?? null
+      return {
+        ...o,
+        fecha,
+        area_productiva,
+        area_cama,
+        area_observacion,
+      } as AnyRow
     })
 
-    return augmented as any[]
+    return augmented
   }, [], { defer: false })
 
-  const baseColumns = getTableConfig('observacion')?.columns ?? []
-  const columns = React.useMemo(() => {
-    const filtered = baseColumns.filter((c: any) => c.key !== 'creado_en' && c.key !== 'fecha')
-    const fmtNum = (v: number) => (Number(v || 0)).toLocaleString(undefined, { maximumFractionDigits: 2 })
-    const fmtFecha = (v: any) => formatDate(v)
+  const baseColumns = getTableConfig('observacion')?.columns
+  const columns = React.useMemo<Column<AnyRow>[]>(() => {
+    const columnDefs = (baseColumns ?? []).filter((c) => c.key !== 'creado_en' && c.key !== 'fecha')
+    const fmtNum = (value: unknown) => (Number(value ?? 0)).toLocaleString(undefined, { maximumFractionDigits: 2 })
+    const fmtFecha = (value: unknown) => formatDate(value)
+    const derived: Column<AnyRow>[] = columnDefs.map((c) => ({
+      key: c.key as keyof AnyRow,
+      header: c.header,
+    }))
     return [
-      { key: 'fecha', header: 'Fecha', render: (v: any) => fmtFecha(v) },
-      ...filtered,
-      { key: 'area_observacion', header: 'Área observación (m²)', render: (v: number) => fmtNum(v) },
-      { key: 'area_cama', header: 'Área cama (m²)', render: (v: number) => fmtNum(v) },
-      { key: 'area_productiva', header: 'Área productiva (m²)', render: (v: number) => fmtNum(v) },
+      { key: 'fecha', header: 'Fecha', render: (value) => fmtFecha(value) },
+      ...derived,
+      { key: 'area_observacion', header: 'Área observación (m²)', render: (value) => fmtNum(value) },
+      { key: 'area_cama', header: 'Área cama (m²)', render: (value) => fmtNum(value) },
+      { key: 'area_productiva', header: 'Área productiva (m²)', render: (value) => fmtNum(value) },
     ]
-  }, [JSON.stringify(baseColumns)]) as any
+  }, [baseColumns])
 
   const { displayRows } = useDottedLookups('observacion', data ?? [], columns)
+  const skeletonColumns = React.useMemo(() => columns.map((c) => ({ key: String(c.key), header: c.header })), [columns])
 
   return (
     <div className="h-full min-h-0 min-w-0 flex flex-col overflow-hidden">
       {loading ? (
-        <DataTableSkeleton columns={columns as any} rows={8} />
+        <DataTableSkeleton columns={skeletonColumns} rows={8} />
       ) : (
         <DataTable caption={`${displayRows.length}`} columns={columns} rows={displayRows} />
       )}

--- a/src/routes/estimados/observaciones-resumen.tsx
+++ b/src/routes/estimados/observaciones-resumen.tsx
@@ -1,14 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as React from 'react'
 import { useDeferredLiveQuery } from '@/hooks/use-deferred-live-query'
-import { getStore } from '@/lib/dexie'
-import { DataTable } from '@/components/data-table'
+import { getStore, type AnyRow } from '@/lib/dexie'
+import { DataTable, type Column } from '@/components/data-table'
 import { DataTableSkeleton } from '@/components/data-table-skeleton'
 import { supabase } from '@/lib/supabase'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { formatDate, formatDateRange } from '@/lib/utils'
 
-export const Route = createFileRoute('/estimados/observaciones-resumen' as any)({
+export const Route = createFileRoute('/estimados/observaciones-resumen')({
     component: Page,
 })
 
@@ -27,15 +27,15 @@ type Row = {
     area_productiva: number
 }
 
+type SourceEntry = AnyRow & { area_observada: number; cantidad: number }
+
 function Page() {
-    const { data, loading } = useDeferredLiveQuery<{ rows: Row[]; sources: Map<string, any[]> } | undefined>(async () => {
-        const parseNumber = (val: any): number => {
-            if (typeof val === 'number') return isFinite(val) ? val : 0
+    const { data, loading } = useDeferredLiveQuery<{ rows: Row[]; sources: Map<string, SourceEntry[]> } | undefined>(async () => {
+        const parseNumber = (val: unknown): number => {
+            if (typeof val === 'number') return Number.isFinite(val) ? val : 0
             if (typeof val === 'string') {
                 const s = val.trim()
                 if (!s) return 0
-                // Handle common locales: "1.234,56" -> 1234.56, "1,234.56" -> 1234.56
-                // Heuristic: if there is a comma and either no dot or both separators exist, treat comma as decimal and dots as thousand sep.
                 const hasComma = s.includes(',')
                 const hasDot = s.includes('.')
                 let normalized = s
@@ -43,12 +43,19 @@ function Page() {
                     normalized = s.replace(/\./g, '').replace(/,/g, '.')
                 }
                 const n = Number(normalized)
-                return isNaN(n) ? 0 : n
+                return Number.isNaN(n) ? 0 : n
             }
             return 0
         }
 
-        const [observaciones, camas, grupos, bloques, fincas, variedades] = await Promise.all([
+        const [observaciones, camas, grupos, bloques, fincas, variedades] = await Promise.all<[
+            AnyRow[],
+            AnyRow[],
+            AnyRow[],
+            AnyRow[],
+            AnyRow[],
+            AnyRow[],
+        ]>([
             getStore('observacion').toArray(),
             getStore('cama').toArray(),
             getStore('grupo_cama').toArray(),
@@ -57,105 +64,107 @@ function Page() {
             getStore('variedad').toArray(),
         ])
 
-        // seccion.largo_m (single row used for all camas)
         let seccionLargoM = 0
         try {
             const secciones = await getStore('seccion').toArray()
-            if (secciones && secciones.length > 0) {
-                const s0: any = (secciones as any[])[0]
-                seccionLargoM = Number(s0?.largo_m) || 0
+            if (secciones.length > 0) {
+                seccionLargoM = Number(secciones[0]?.['largo_m']) || 0
             }
         } catch {
             const { data: secData } = await supabase.from('seccion').select('largo_m').limit(1)
-            if (secData && secData.length > 0) {
-                const s0: any = (secData as any[])[0]
-                seccionLargoM = Number(s0?.largo_m) || 0
+            if (Array.isArray(secData) && secData.length > 0) {
+                seccionLargoM = Number((secData[0] as AnyRow)?.['largo_m']) || 0
             }
         }
 
-        const mapBy = <T extends Record<string, any>>(arr: T[], key: string) => {
+        const mapBy = <T extends Record<string, unknown>>(arr: T[], key: string) => {
             const m = new Map<string, T>()
-            for (const it of arr) m.set(String(it[key]), it)
+            for (const it of arr) {
+                const id = it?.[key]
+                if (id == null) continue
+                m.set(String(id), it)
+            }
             return m
         }
 
-        const camasById = mapBy(camas as any[], 'id_cama')
-        const gruposById = mapBy(grupos as any[], 'id_grupo')
-        const bloquesById = mapBy(bloques as any[], 'id_bloque')
-        const fincasById = mapBy(fincas as any[], 'id_finca')
-        const variedadesById = mapBy(variedades as any[], 'id_variedad')
+        const camasById = mapBy(camas, 'id_cama')
+        const gruposById = mapBy(grupos, 'id_grupo')
+        const bloquesById = mapBy(bloques, 'id_bloque')
+        const fincasById = mapBy(fincas, 'id_finca')
+        const variedadesById = mapBy(variedades, 'id_variedad')
 
-        // Precompute area productiva per (bloque,variedad) across productivo grupos
         const ESTADO_PRODUCTIVO = 'productivo'
         const areaByBloqueVar = new Map<string, number>()
-        for (const c of camas as any[]) {
-            const g = gruposById.get(String((c as any).id_grupo))
-            if (!g) continue
-            const estado = String((g as any).estado ?? '').toLowerCase()
+        for (const cama of camas) {
+            const grupo = gruposById.get(String(cama?.['id_grupo']))
+            if (!grupo) continue
+            const estado = String(grupo?.['estado'] ?? '').toLowerCase()
             if (estado !== ESTADO_PRODUCTIVO) continue
-            const key = `${String((g as any).id_bloque)}|${String((g as any).id_variedad)}`
-            const largo = Number((c as any).largo_metros) || 0
-            const ancho = Number((c as any).ancho_metros) || 0
+            const key = `${String(grupo?.['id_bloque'])}|${String(grupo?.['id_variedad'])}`
+            const largo = Number(cama?.['largo_metros']) || 0
+            const ancho = Number(cama?.['ancho_metros']) || 0
             const area = largo * ancho
             areaByBloqueVar.set(key, (areaByBloqueVar.get(key) || 0) + area)
         }
 
-        // Group by (id_cama, tipo_observacion)
         const acc = new Map<string, Row>()
-        const sources = new Map<string, any[]>()
-        for (const o of (observaciones as any[])) {
-            const idCama = String(o?.id_cama ?? '')
-            if (!idCama) continue
-            const cama = camasById.get(idCama)
+        const sources = new Map<string, SourceEntry[]>()
+
+        for (const obs of observaciones) {
+            const idCama = obs?.['id_cama']
+            if (idCama == null) continue
+            const cama = camasById.get(String(idCama))
             if (!cama) continue
-            const ancho = Number((cama as any)?.ancho_metros) || 0
+            const grupo = gruposById.get(String(cama?.['id_grupo']))
+            if (!grupo) continue
+            const bloque = bloquesById.get(String(grupo?.['id_bloque']))
+            const finca = bloque ? fincasById.get(String(bloque?.['id_finca'])) : undefined
+            const variedad = variedadesById.get(String(grupo?.['id_variedad']))
+            const tipo = String(obs?.['tipo_observacion'] ?? '')
+
+            const ancho = Number(cama?.['ancho_metros']) || 0
+            const largo = Number(cama?.['largo_metros']) || 0
+            const areaCama = largo * ancho
             const areaObs = (Number(seccionLargoM) || 0) * ancho
-            const cant = parseNumber((o as any)?.cantidad)
-            const g = gruposById.get(String((cama as any)?.id_grupo))
-            const b = g ? bloquesById.get(String((g as any)?.id_bloque)) : undefined
-            const f = b ? fincasById.get(String((b as any)?.id_finca)) : undefined
-            const v = g ? variedadesById.get(String((g as any)?.id_variedad)) : undefined
-            const tipo = String(o?.tipo_observacion ?? '')
-            const key = `${idCama}|${tipo}`
+            const cantidad = parseNumber(obs?.['cantidad'])
+
+            const key = `${String(idCama)}|${tipo}`
             const existing = acc.get(key)
-            const rawDate: any = (o as any)?.creado_en ?? (o as any)?.fecha ?? null
+            const rawDate = obs?.['creado_en'] ?? obs?.['fecha']
             const curDate = rawDate ? new Date(rawDate) : null
 
             if (existing) {
                 existing.area_observada += areaObs
-                existing.cantidad_total += cant
-                if (curDate && !isNaN(curDate.getTime())) {
+                existing.cantidad_total += cantidad
+                if (curDate && !Number.isNaN(curDate.getTime())) {
                     const desde = existing.fecha_desde ? new Date(existing.fecha_desde) : null
                     const hasta = existing.fecha_hasta ? new Date(existing.fecha_hasta) : null
                     if (!desde || curDate < desde) existing.fecha_desde = curDate.toISOString()
                     if (!hasta || curDate > hasta) existing.fecha_hasta = curDate.toISOString()
                 }
             } else {
-                const gKey = g ? `${String((g as any).id_bloque)}|${String((g as any).id_variedad)}` : 'x|x'
-                const largo = Number((cama as any)?.largo_metros) || 0
-                const areaCama = largo * ancho
+                const gKey = `${String(grupo?.['id_bloque'])}|${String(grupo?.['id_variedad'])}`
                 acc.set(key, {
-                    id_cama: (cama as any)?.id_cama,
-                    cama: String((cama as any)?.nombre ?? ''),
-                    bloque: String((b as any)?.nombre ?? ''),
-                    finca: String((f as any)?.nombre ?? ''),
-                    variedad: String((v as any)?.nombre ?? ''),
+                    id_cama: cama?.['id_cama'] as string | number,
+                    cama: String(cama?.['nombre'] ?? ''),
+                    bloque: String(bloque?.['nombre'] ?? ''),
+                    finca: String(finca?.['nombre'] ?? ''),
+                    variedad: String(variedad?.['nombre'] ?? ''),
                     tipo_observacion: tipo,
-                    fecha_desde: curDate && !isNaN(curDate.getTime()) ? curDate.toISOString() : null,
-                    fecha_hasta: curDate && !isNaN(curDate.getTime()) ? curDate.toISOString() : null,
+                    fecha_desde: curDate && !Number.isNaN(curDate.getTime()) ? curDate.toISOString() : null,
+                    fecha_hasta: curDate && !Number.isNaN(curDate.getTime()) ? curDate.toISOString() : null,
                     area_observada: areaObs,
-                    cantidad_total: cant,
+                    cantidad_total: cantidad,
                     area_cama: areaCama,
-                    area_productiva: g ? (areaByBloqueVar.get(gKey) || 0) : 0,
+                    area_productiva: areaByBloqueVar.get(gKey) || 0,
                 })
             }
 
-            const list = sources.get(key) || []
-            list.push({ ...o, area_observada: areaObs, cantidad: cant })
+            const list = sources.get(key) ?? []
+            list.push({ ...obs, area_observada: areaObs, cantidad })
             sources.set(key, list)
         }
 
-        // Sort for stable display
         const rows = Array.from(acc.values()).sort((a, b) =>
             a.finca.localeCompare(b.finca, undefined, { sensitivity: 'base' }) ||
             a.bloque.localeCompare(b.bloque, undefined, { sensitivity: 'base' }) ||
@@ -167,38 +176,46 @@ function Page() {
         return { rows, sources }
     }, [], { defer: false })
 
-    const rows: Row[] = (data as any)?.rows ?? []
-    const sources: Map<string, any[]> = (data as any)?.sources ?? new Map<string, any[]>()
+    const rows = React.useMemo(() => data?.rows ?? [], [data])
+    const sources = React.useMemo(() => data?.sources ?? new Map<string, SourceEntry[]>(), [data])
 
     const [open, setOpen] = React.useState(false)
     const [selectedKey, setSelectedKey] = React.useState<string | null>(null)
-    const selectedRow = React.useMemo(() => rows.find((r) => `${r.id_cama}|${r.tipo_observacion}` === selectedKey) ?? null, [rows, selectedKey])
+    const selectedRow = React.useMemo(
+        () => rows.find((r) => `${r.id_cama}|${r.tipo_observacion}` === selectedKey) ?? null,
+        [rows, selectedKey],
+    )
 
-    const fmt = (v: number) => (Number(v || 0)).toLocaleString(undefined, { maximumFractionDigits: 2 })
-    const columns = React.useMemo(() => ([
-        { key: 'finca', header: 'Finca' },
-        { key: 'bloque', header: 'Bloque' },
-        { key: 'variedad', header: 'Variedad' },
-        { key: 'cama', header: 'Cama' },
-        { key: 'tipo_observacion', header: 'Estado fenológico' },
-        { key: 'fecha_desde', header: 'Fecha', render: (_: any, row: Row) => formatDateRange(row.fecha_desde, row.fecha_hasta) },
-        { key: 'cantidad_total', header: 'Cantidad' },
-        { key: 'area_observada', header: 'Área observada (m²)', render: (v: number) => fmt(v as any) },
-        { key: 'area_cama', header: 'Área cama (m²)', render: (v: number) => fmt(v as any) },
-        { key: 'area_productiva', header: 'Área productiva (m²)', render: (v: number) => fmt(v as any) },
-    ]), []) as any
+    const fmt = (value: unknown) => (Number(value ?? 0)).toLocaleString(undefined, { maximumFractionDigits: 2 })
+    const columns = React.useMemo<Column<Row>[]>(
+        () => [
+            { key: 'finca', header: 'Finca' },
+            { key: 'bloque', header: 'Bloque' },
+            { key: 'variedad', header: 'Variedad' },
+            { key: 'cama', header: 'Cama' },
+            { key: 'tipo_observacion', header: 'Estado fenológico' },
+            { key: 'fecha_desde', header: 'Fecha', render: (_, row) => formatDateRange(row.fecha_desde, row.fecha_hasta) },
+            { key: 'cantidad_total', header: 'Cantidad' },
+            { key: 'area_observada', header: 'Área observada (m²)', render: (value) => fmt(value) },
+            { key: 'area_cama', header: 'Área cama (m²)', render: (value) => fmt(value) },
+            { key: 'area_productiva', header: 'Área productiva (m²)', render: (value) => fmt(value) },
+        ],
+        [],
+    )
+
+    const skeletonColumns = React.useMemo(() => columns.map((c) => ({ key: String(c.key), header: c.header })), [columns])
 
     return (
         <div className="h-full min-h-0 min-w-0 flex flex-col overflow-hidden">
             {loading ? (
-                <DataTableSkeleton columns={columns as any} rows={8} />
+                <DataTableSkeleton columns={skeletonColumns} rows={8} />
             ) : (
                 <DataTable
-                    caption={`${rows?.length ?? 0}`}
+                    caption={`${rows.length}`}
                     columns={columns}
-                    rows={rows ?? []}
-                    getRowKey={(r: Row) => `${r.id_cama}|${r.tipo_observacion}`}
-                    onRowClick={(r: Row) => {
+                    rows={rows}
+                    getRowKey={(r) => `${r.id_cama}|${r.tipo_observacion}`}
+                    onRowClick={(r) => {
                         setSelectedKey(`${r.id_cama}|${r.tipo_observacion}`)
                         setOpen(true)
                     }}
@@ -211,9 +228,9 @@ function Page() {
                         <DialogTitle>Observaciones</DialogTitle>
                         {selectedRow ? (
                             <DialogDescription>
-                                <span className="font-medium">Finca:</span> {selectedRow.finca} {' '}
-                                <span className="font-medium">Bloque:</span> {selectedRow.bloque} {' '}
-                                <span className="font-medium">Cama:</span> {selectedRow.cama} {' '}
+                                <span className="font-medium">Finca:</span> {selectedRow.finca}{' '}
+                                <span className="font-medium">Bloque:</span> {selectedRow.bloque}{' '}
+                                <span className="font-medium">Cama:</span> {selectedRow.cama}{' '}
                                 <span className="font-medium">Estado fenológico:</span> {selectedRow.tipo_observacion}
                             </DialogDescription>
                         ) : null}
@@ -236,13 +253,13 @@ function Page() {
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                                {list.map((o: any, idx: number) => (
+                                                {list.map((o, idx) => (
                                                     <tr key={idx} className="border-b last:border-b-0">
-                                                        <td className="py-1.5 px-2 whitespace-nowrap">{formatDate(o.creado_en ?? o.fecha)}</td>
-                                                        <td className="py-1.5 px-2 whitespace-nowrap">{o.tipo_observacion ?? ''}</td>
-                                                        <td className="py-1.5 px-2 whitespace-nowrap">{Number(o.cantidad || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}</td>
-                                                        <td className="py-1.5 px-2 whitespace-nowrap">{Number(o.area_observada || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}</td>
-                                                        <td className="py-1.5 px-2">{o.notas ?? o.descripcion ?? ''}</td>
+                                                        <td className="py-1.5 px-2 whitespace-nowrap">{formatDate(o['creado_en'] ?? o['fecha'])}</td>
+                                                        <td className="py-1.5 px-2 whitespace-nowrap">{String(o['tipo_observacion'] ?? '')}</td>
+                                                        <td className="py-1.5 px-2 whitespace-nowrap">{Number(o['cantidad'] || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}</td>
+                                                        <td className="py-1.5 px-2 whitespace-nowrap">{Number(o['area_observada'] || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}</td>
+                                                        <td className="py-1.5 px-2">{String(o['notas'] ?? o['descripcion'] ?? '')}</td>
                                                     </tr>
                                                 ))}
                                             </tbody>

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,8 +1,10 @@
 import { supabase } from '@/lib/supabase'
 
+type TableRow = Record<string, unknown>
+
 // Generic factory for per-table services
 // Provide Row, Insert, Update types optionally for stronger typing.
-export function makeTableService<Row = any, Insert = Partial<Row>, Update = Partial<Row>>(table: string) {
+export function makeTableService<Row extends TableRow = TableRow, Insert = Partial<Row>, Update = Partial<Row>>(table: string) {
     return {
         // Basic reads
         selectAll: (columns: string = '*') => supabase.from(table).select(columns),
@@ -10,10 +12,10 @@ export function makeTableService<Row = any, Insert = Partial<Row>, Update = Part
             supabase.from(table).select(columns).eq(idColumn, id).single(),
 
         // Inserts and updates
-        insert: (values: Insert) => supabase.from(table).insert(values as any).select().single(),
-        upsert: (values: Insert | Insert[]) => supabase.from(table).upsert(values as any).select(),
+        insert: (values: Insert) => supabase.from(table).insert(values).select().single(),
+        upsert: (values: Insert | Insert[]) => supabase.from(table).upsert(values).select(),
         updateById: (id: string | number, patch: Update, idColumn: string = 'id') =>
-            supabase.from(table).update(patch as any).eq(idColumn, id).select().single(),
+            supabase.from(table).update(patch).eq(idColumn, id).select().single(),
 
         // Deletes
         deleteById: (id: string | number, idColumn: string = 'id') =>
@@ -26,186 +28,27 @@ export function getTableService(table: string) {
     return makeTableService(table)
 }
 
-// --- Config registry for generic DB browsing ---
-export type TableColumn = {
-    key: string
-    header?: string
-}
-
-export type TableConfig = {
-    id: string
-    title: string
-    columns: TableColumn[]
-}
-
-// Small helper to declare columns without repeating `{ key: '...' }`
-const cols = (...keys: string[]): TableColumn[] => keys.map((key) => ({ key }))
-
-export const TABLES: Record<string, TableConfig> = {
-    finca: {
-        id: 'finca',
-        title: 'Finca',
-        columns: cols('id_finca', 'nombre',
-            // 'creado_en', 'eliminado_en'
-        ),
-    },
-    bloque: {
-        id: 'bloque',
-        title: 'Bloque',
-        columns: cols('id_bloque', 'finca.nombre', 'nombre', 'numero_camas',
-            // 'area_m2',
-            // 'creado_en', 'eliminado_en'
-        ),
-    },
-    grupo_cama: {
-        id: 'grupo_cama',
-        title: 'Grupo cama',
-        columns: cols(
-            'id_grupo',
-            'bloque.nombre',
-            'variedad.nombre',
-            'fecha_siembra',
-            'patron',
-            'estado',
-            'tipo_planta',
-            'numero_camas',
-            'total_plantas',
-            // 'creado_en',
-            // 'eliminado_en',
-        ),
-    },
-    cama: {
-        id: 'cama',
-        title: 'Cama',
-        columns: cols(
-            'id_cama',
-            // 'id_grupo',
-            'finca.nombre',
-            'bloque.nombre',
-            'variedad.nombre',
-            'nombre',
-            'largo_metros',
-            'ancho_metros',
-            // 'plantas_totales',
-            // 'creado_en',
-            // 'eliminado_en',
-        ),
-    },
-    breeder: {
-        id: 'breeder',
-        title: 'Breeder',
-        columns: cols('id_breeder', 'nombre',
-            // 'creado_en', 'eliminado_en'
-        ),
-    },
-    estado_fenologico_tipo: {
-        id: 'estado_fenologico_tipo',
-        title: 'Estado fenológico tipo',
-        columns: cols('codigo',
-            // 'creado_en',
-            'orden'),
-    },
-    estados_fenologicos: {
-        id: 'estados_fenologicos',
-        title: 'Estados fenológicos',
-        columns: cols(
-            'id_estado_fenologico',
-            'id_finca',
-            'id_bloque',
-            'id_variedad',
-            'dias_brotacion',
-            'dias_cincuenta_mm',
-            'dias_quince_cm',
-            'dias_veinte_cm',
-            'dias_primera_hoja',
-            'dias_espiga',
-            'dias_arroz',
-            'dias_arveja',
-            'dias_garbanzo',
-            'dias_uva',
-            'dias_rayando_color',
-            'dias_sepalos_abiertos',
-            'dias_cosecha',
-            // 'creado_en',
-            // 'eliminado_en',
-        ),
-    },
-    grupo_cama_estado: {
-        id: 'grupo_cama_estado',
-        title: 'Grupo cama estado',
-        columns: cols('codigo'),
-    },
-    grupo_cama_tipo_planta: {
-        id: 'grupo_cama_tipo_planta',
-        title: 'Grupo cama tipo planta',
-        columns: cols('codigo'),
-    },
-    observacion: {
-        id: 'observacion',
-        title: 'Observación',
-        columns: cols(
-            // 'id_observacion',
-            'creado_en',
-            'finca.nombre',
-            'bloque.nombre',
-            'variedad.nombre',
-            'cama.nombre',
-            'ubicacion_seccion',
-            'tipo_observacion',
-            'cantidad',
-            'id_usuario',
-            // 'eliminado_en',
-        ),
-    },
-    patron: {
-        id: 'patron',
-        title: 'Patrón',
-        columns: cols('codigo',
-            // 'proveedor'
-        ),
-    },
-    variedad: {
-        id: 'variedad',
-        title: 'Variedad',
-        columns: cols('id_variedad', 'breeder.nombre', 'nombre',
-            // 'creado_en', 'eliminado_en', 
-            'color'),
-    },
-    usuario: {
-        id: 'usuario',
-        title: 'Usuario',
-        columns: cols('id_usuario', 'creado_en', 'nombres', 'apellidos', 'rol', 'clave_pin'),
-    },
-    seccion: {
-        id: 'seccion',
-        title: 'Sección',
-        columns: cols('largo_m'),
-    },
-}
-
-export function getTableConfig(id: string): TableConfig | undefined {
-    return TABLES[id]
-}
-
-// Sidebar/Navigation grouping with display order
-// (UI-only) TABLE_GROUPS moved to '@/config/tables' to keep services free of presentation concerns.
-
 // Small helper to add standard PK-based convenience methods to a base service
 function withIdConvenience<TBase extends {
-    selectById: (id: any, idColumn?: string, columns?: string) => any
-    updateById: (id: any, patch: any, idColumn?: string) => any
-    deleteById: (id: any, idColumn?: string) => any
+    selectById: (id: string | number, idColumn?: string, columns?: string) => unknown
+    updateById: (id: string | number, patch: unknown, idColumn?: string) => unknown
+    deleteById: (id: string | number, idColumn?: string) => unknown
 }>(base: TBase, idColumn: string) {
+    type Patch = Parameters<TBase['updateById']>[1]
+    type SelectReturn = ReturnType<TBase['selectById']>
+    type UpdateReturn = ReturnType<TBase['updateById']>
+    type DeleteReturn = ReturnType<TBase['deleteById']>
+
     return {
         ...base,
-        getById: (id: string | number, columns: string = '*') => base.selectById(id, idColumn, columns),
-        updateById: (id: string | number, patch: any) => base.updateById(id, patch, idColumn),
-        deleteById: (id: string | number) => base.deleteById(id, idColumn),
+        getById: (id: string | number, columns: string = '*'): SelectReturn => base.selectById(id, idColumn, columns),
+        updateById: (id: string | number, patch: Patch): UpdateReturn => base.updateById(id, patch, idColumn),
+        deleteById: (id: string | number): DeleteReturn => base.deleteById(id, idColumn),
     }
 }
 
 // Consolidated per-table services generated from a single config
-export const SERVICE_PK: Record<string, string> = {
+export const SERVICE_PK = {
     bloque: 'id_bloque',
     breeder: 'id_breeder',
     cama: 'id_cama',
@@ -219,11 +62,23 @@ export const SERVICE_PK: Record<string, string> = {
     patron: 'codigo',
     variedad: 'id_variedad',
     usuario: 'id_usuario',
+} as const satisfies Record<string, string>
+
+type ServiceName = keyof typeof SERVICE_PK
+type BaseService = ReturnType<typeof makeTableService>
+type ServiceWithConvenience = BaseService & {
+    getById: (id: string | number, columns?: string) => ReturnType<BaseService['selectById']>
+    updateById: (id: string | number, patch: Parameters<BaseService['updateById']>[1]) => ReturnType<BaseService['updateById']>
+    deleteById: (id: string | number) => ReturnType<BaseService['deleteById']>
 }
 
-const SERVICES = Object.fromEntries(
-    Object.entries(SERVICE_PK).map(([name, pk]) => [name, withIdConvenience(makeTableService(name), pk)])
-) as any
+const SERVICES: Record<ServiceName, ServiceWithConvenience> = (Object.keys(SERVICE_PK) as ServiceName[]).reduce(
+    (acc, name) => {
+        acc[name] = withIdConvenience(makeTableService(name), SERVICE_PK[name])
+        return acc
+    },
+    {} as Record<ServiceName, ServiceWithConvenience>
+)
 
 export const {
     bloque: bloqueService,

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -1,11 +1,11 @@
-import { getStore, initDexieSchema } from '@/lib/dexie'
+import { getStore, initDexieSchema, type AnyRow } from '@/lib/dexie'
 import { SERVICE_PK } from '@/services/db'
 import { supabase } from '@/lib/supabase'
 
 export type SyncResult = { table: string; count: number }
 
 // Upsert array of rows into Dexie using the configured PK
-async function upsertIntoDexie(table: string, rows: any[]) {
+async function upsertIntoDexie(table: string, rows: AnyRow[]) {
     const store = getStore(table)
     await store.bulkPut(rows)
 }
@@ -34,7 +34,7 @@ export async function syncTable(table: string): Promise<SyncResult> {
             .range(from, to)
 
         if (error) throw new Error(`Failed to fetch ${table} page starting at ${from}: ${error.message}`)
-        const rows = (data as any[]) ?? []
+        const rows: AnyRow[] = Array.isArray(data) ? (data as AnyRow[]) : []
         if (rows.length === 0) break
 
         await upsertIntoDexie(table, rows)


### PR DESCRIPTION
## Summary
- re-enable the strict TypeScript ESLint rules and replace the previous `any` usages with typed helpers and generics across shared hooks and utilities
- refactor Dexie-backed routes and table utilities to use strongly typed records, memoized data, and typed table configurations without circular dependencies
- update date-picker, data-table, and various estimados/observaciones pages to compute derived data with typed reducers while keeping filtering and dialogs functional

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb0b5fa2408329827dfd79a317fdda